### PR TITLE
Require Corepack

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,3 @@ Please explain the changes you made here.
 - [ ] Created tests which fail without the change (if possible)
 - [ ] All tests passing
 - [ ] Extended the README / documentation, if necessary
-- [ ] Added myself / the copyright holder to the AUTHORS file

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,6 @@
-yarnPath: .yarn/releases/yarn-4.1.0.cjs
+# nodeLinker is used because some node packages are not yet supported
+# using yarn's new build and package installation procedures. This is
+# why we currently use nodeLinker. In this future, this option may
+# not be required. For now though:
+# https://yarnpkg.com/configuration/yarnrc#nodeLinker
 nodeLinker: "node-modules"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,25 @@ Our current website exists at a Wordpress host on GoDaddy. We are in the process
 
 Please first have __yarn__ installed on your computer first before starting development.
 
-Clone the repo. In the root directory run ```yarn```. This will install all necessary files.
+### MacOS
+
+If you're using MacOS the brew package ```corepack``` is needed. Corepack ships with Node, but zsh does not find this linkage in the shell. Therefore, since we are using brew, corepack can be installed with:
+
+```brew install corepack```
+
+Brew may error and say that you must remove the symlink for ```yarn``` if you used brew to install yarn. Do not fret, run this command:
+
+```brew unlink yarn```
+
+Then, rerun ```brew install corepack```.
+
+Now, run ```corepack enable```. This will enable corepack globally. Optionally, one can run ```corepack install --global yarn@stable``` to install the latest yarn version globally using corepack.
+
+To set the yarn version in the frontend directory, first ```cd frontend``` then ```corepack use yarn@v```, where ```v``` is the version you want to set. In this project, we are using stable, so the command would be ```corepack use yarn@stable```.
+
+## Development
+
+In the root directory on this repository, run ```yarn```. This will install all necessary files.
 
 To start development for either backend or frontend, run ```yarn dev``` in their respective directories.
 


### PR DESCRIPTION
### Description
Remove .yarn/releases dependency, now require use of corepack for local development environment and testing. Corepack manages yarn versions. It ships with an installation of Node. Documentation installation for corepack on MacOS was also added, since it is a little different than Linux/Windows installation even when MacOS has node installed.

### Checklist
- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
