### PR TITLE
`package.json` yarn version retrieval and minor formatting

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Set yarn version
         id: set_yarn_version
         run: |
-          echo "yarn_version=${{ env.YARN_VERSION }}" >> "$GITHUB_ENV"
+          echo "yarn_version=${{ env.YARN_VERSION }}" >> $GITHUB_OUTPUT
 
         # Yarn installation
       - name: Enable corepack

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -122,12 +122,12 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
 
       # Retrieve yarn version from package.json
-      - name: Get yarn version
+      - name: Get yarn version from package.json
         run: |
           grep 'packageManager' package.json | awk -F: '{gsub(/[", ]/, "", $2); print $2}' | xargs -I {} echo "YARN_VERSION="{} >> "$GITHUB_ENV"
 
       # Set the yarn version by exporting to env var and output
-      - name: Set yarn version
+      - name: Append yarn version to $GITHUB_OUTPUT
         id: set_yarn_version
         run: |
           echo "yarn_version=${{ env.YARN_VERSION }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -31,6 +31,7 @@ on:
       - ".env.example"
 
       # Ignore changes in frontend package.
+      - ".github/workflows/frontend.yml"
       - "packages/frontend/**"
 
       # Ignore frontend package specific paths.

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -108,6 +108,8 @@ jobs:
 
   setup:
     runs-on: ubuntu-latest
+    outputs:
+      yarn_version: ${{ steps.set_yarn_version.outputs.yarn_version }}
     environment: ${{ needs.set-environment.outputs.current_env }}
     needs: set-environment
     steps:
@@ -115,17 +117,29 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: ${{ vars.NODE_VERSION }}
+
+      # Retrieve yarn version from package.json
+      - name: Get yarn version
+        run: |
+          echo "yarn_version=" >> "$GITHUB_ENV"
+          grep 'packageManager' package.json | awk -F: '{gsub(/[", ]/, "", $2); print $2}' | xargs -I {} echo "YARN_VERSION="{} >> "$GITHUB_ENV"
+
+      # Set the yarn version by exporting to env var and output
+      - name: Set yarn version
+        id: set_yarn_version
+        run: |
+          echo "yarn_version=${{ env.YARN_VERSION }}" >> "$GITHUB_ENV"
 
         # Yarn installation
       - name: Enable corepack
         run: corepack enable
 
       - name: Install yarn
-        run: corepack install --global yarn@${{ vars.YARN_VERSION }}
+        run: corepack install --global ${{ env.YARN_VERSION }}
 
       - name: Set yarn version
-        run: corepack use yarn@stable
+        run: corepack use ${{ env.YARN_VERSION }}
 
       - name: Install dependencies
         run: yarn --immutable
@@ -156,17 +170,17 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: ${{ vars.NODE_VERSION }}
 
       # Yarn installation
       - name: Enable corepack
         run: corepack enable
 
       - name: Install yarn
-        run: corepack install --global yarn@${{ vars.YARN_VERSION }}
+        run: corepack install --global ${{ needs.setup.outputs.yarn_version }}
 
       - name: Set yarn version
-        run: corepack use yarn@stable
+        run: corepack use ${{ needs.setup.outputs.yarn_version }}
 
         # ============================================== #
         # Retrieve cached dependencies from previous job #

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -90,16 +90,16 @@ jobs:
       - name: Check if production
         if: github.ref_name == 'production'
         run: |
-          echo "ENVIRONMENT_NAME=production" >> $GITHUB_ENV
+          echo "ENVIRONMENT_NAME=production" >> "$GITHUB_ENV"
       - name: Check if staging
         if: github.ref_name == 'staging'
         run: |
-          echo "ENVIRONMENT_NAME=staging" >> $GITHUB_ENV
+          echo "ENVIRONMENT_NAME=staging" >> "$GITHUB_ENV"
 
       - name: Check if development
         if: github.ref_name == 'dev'
         run: |
-          echo "ENVIRONMENT_NAME=development" >> $GITHUB_ENV
+          echo "ENVIRONMENT_NAME=development" >> "$GITHUB_ENV"
 
       # Original: https://magnussundstrom.se/blog/github-action-environment-check
       # Edited, due to: https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/
@@ -124,13 +124,13 @@ jobs:
       # Retrieve yarn version from package.json
       - name: Get yarn version
         run: |
-          grep 'packageManager' package.json | awk -F: '{gsub(/[", ]/, "", $2); print $2}' | xargs -I {} echo "YARN_VERSION="{} >> $GITHUB_ENV
+          grep 'packageManager' package.json | awk -F: '{gsub(/[", ]/, "", $2); print $2}' | xargs -I {} echo "YARN_VERSION="{} >> "$GITHUB_ENV"
 
       # Set the yarn version by exporting to env var and output
       - name: Set yarn version
         id: set_yarn_version
         run: |
-          echo "yarn_version=${{ env.YARN_VERSION }}" >> $GITHUB_OUTPUT
+          echo "yarn_version=${{ env.YARN_VERSION }}" >> "$GITHUB_OUTPUT"
 
         # Yarn installation
       - name: Enable corepack
@@ -150,7 +150,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: yarn-cache
@@ -192,7 +192,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: yarn-cache

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -123,8 +123,7 @@ jobs:
       # Retrieve yarn version from package.json
       - name: Get yarn version
         run: |
-          echo "yarn_version=" >> "$GITHUB_ENV"
-          grep 'packageManager' package.json | awk -F: '{gsub(/[", ]/, "", $2); print $2}' | xargs -I {} echo "YARN_VERSION="{} >> "$GITHUB_ENV"
+          grep 'packageManager' package.json | awk -F: '{gsub(/[", ]/, "", $2); print $2}' | xargs -I {} echo "YARN_VERSION="{} >> $GITHUB_ENV
 
       # Set the yarn version by exporting to env var and output
       - name: Set yarn version

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -42,8 +42,7 @@ on:
       - "packages/backend/schemaTypes/**"
 
   push:
-    branches:
-      ["main", "staging", "dev", "48-retrieve-yarn-version-from-packagejson"]
+    branches: ["main", "staging", "dev"]
     paths-ignore:
       # Ignore changes in documentation.
       - "docs/**"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -165,6 +165,9 @@ jobs:
     # https://github.com/orgs/community/discussions/56123#discussioncomment-5968189
     environment: ${{ needs.set-environment.outputs.current_env }}
     needs: setup
+    env:
+      YARN_VERSION: ${{ needs.setup.outputs.yarn_version }}
+
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
@@ -177,10 +180,10 @@ jobs:
         run: corepack enable
 
       - name: Install yarn
-        run: corepack install --global ${{ needs.setup.outputs.yarn_version }}
+        run: corepack install --global ${{ env.YARN_VERSION }}
 
       - name: Set yarn version
-        run: corepack use ${{ needs.setup.outputs.yarn_version }}
+        run: corepack use ${{ env.YARN_VERSION }}
 
         # ============================================== #
         # Retrieve cached dependencies from previous job #

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -41,7 +41,8 @@ on:
       - "packages/backend/schemaTypes/**"
 
   push:
-    branches: ["main", "staging", "dev"]
+    branches:
+      ["main", "staging", "dev", "48-retrieve-yarn-version-from-packagejson"]
     paths-ignore:
       # Ignore changes in documentation.
       - "docs/**"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -43,8 +43,7 @@ on:
       - "packages/frontend/svelte.config.js"
 
   push:
-    branches:
-      ["main", "staging", "dev", "48-retrieve-yarn-version-from-packagejson"]
+    branches: ["main", "staging", "dev"]
     paths-ignore:
       # Ignore changes in documentation.
       - "docs/**"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -109,8 +109,11 @@ jobs:
         run: echo "current_env=${{ env.ENVIRONMENT_NAME }}" >> "$GITHUB_ENV"
 
   # Setup and build the yarn cache for the rest of the jobs.
+  # Also exports yarn version from package.json.
   setup:
     runs-on: ubuntu-latest
+    outputs:
+      yarn_version: ${{ steps.set_yarn_version.outputs.yarn_version }}
     environment: ${{ needs.set-environment.outputs.current_env }}
     needs: set-environment
     steps:
@@ -118,17 +121,29 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: ${{ vars.NODE_VERSION }}
+
+      # Retrieve yarn version from package.json
+      - name: Get yarn version
+        run: |
+          echo "yarn_version=" >> "$GITHUB_ENV"
+          grep 'packageManager' package.json | awk -F: '{gsub(/[", ]/, "", $2); print $2}' | xargs -I {} echo "YARN_VERSION="{} >> "$GITHUB_ENV"
+
+      # Set the yarn version by exporting to env var and output
+      - name: Set yarn version
+        id: set_yarn_version
+        run: |
+          echo "yarn_version=${{ env.YARN_VERSION }}" >> "$GITHUB_ENV"
 
         # Yarn installation
       - name: Enable corepack
         run: corepack enable
 
       - name: Install yarn
-        run: corepack install --global yarn@${{ vars.YARN_VERSION }}
+        run: corepack install --global ${{ env.YARN_VERSION }}
 
       - name: Set yarn version
-        run: corepack use yarn@stable
+        run: corepack use ${{ env.YARN_VERSION }}
 
       - name: Install dependencies
         run: yarn --immutable
@@ -167,17 +182,17 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: ${{ vars.NODE_VERSION }}
 
         # Use corepack
       - name: Enable corepack
         run: corepack enable
 
       - name: Install yarn
-        run: corepack install --global yarn@${{ vars.YARN_VERSION }}
+        run: corepack install --global ${{ needs.setup.outputs.yarn_version }}
 
       - name: Set yarn version
-        run: corepack use yarn@stable
+        run: corepack use  ${{ needs.setup.outputs.yarn_version }}
 
         # ================================================ #
         #  Retrieve cached dependencies from previous job  #
@@ -227,17 +242,17 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: ${{ vars.NODE_VERSION }}
 
         # Use corepack
       - name: Enable corepack
         run: corepack enable
 
       - name: Install yarn
-        run: corepack install --global yarn@${{ vars.YARN_VERSION }}
+        run: corepack install --global ${{ needs.setup.outputs.yarn_version }}
 
       - name: Set yarn version
-        run: corepack use yarn@stable
+        run: corepack use  ${{ needs.setup.outputs.yarn_version }}
 
         # ================================================ #
         #  Retrieve cached dependencies from previous job  #

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -176,6 +176,7 @@ jobs:
       SANITY_API_VERSION: ${{ vars.SANITY_API_VERSION }}
       SANITY_DATASET: ${{ vars.SANITY_DATASET }}
       SANITY_DEVELOPER_TOKEN: ${{ secrets.SANITY_DEVELOPER_TOKEN }}
+      YARN_VERSION: ${{ needs.setup.outputs.yarn_version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -189,10 +190,10 @@ jobs:
         run: corepack enable
 
       - name: Install yarn
-        run: corepack install --global ${{ needs.setup.outputs.yarn_version }}
+        run: corepack install --global ${{ env.YARN_VERSION }}
 
       - name: Set yarn version
-        run: corepack use  ${{ needs.setup.outputs.yarn_version }}
+        run: corepack use  ${{ env.YARN_VERSION }}
 
         # ================================================ #
         #  Retrieve cached dependencies from previous job  #
@@ -237,6 +238,8 @@ jobs:
       SANITY_API_VERSION: ${{ vars.SANITY_API_VERSION }}
       SANITY_DATASET: ${{ vars.SANITY_DATASET }}
       SANITY_DEVELOPER_TOKEN: ${{ secrets.SANITY_DEVELOPER_TOKEN }}
+      YARN_VERSION: ${{ needs.setup.outputs.yarn_version }}
+
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
@@ -249,10 +252,10 @@ jobs:
         run: corepack enable
 
       - name: Install yarn
-        run: corepack install --global ${{ needs.setup.outputs.yarn_version }}
+        run: corepack install --global ${{ env.YARN_VERSION }}
 
       - name: Set yarn version
-        run: corepack use  ${{ needs.setup.outputs.yarn_version }}
+        run: corepack use  ${{ env.YARN_VERSION }}
 
         # ================================================ #
         #  Retrieve cached dependencies from previous job  #

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -126,12 +126,12 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
 
       # Retrieve yarn version from package.json
-      - name: Get yarn version
+      - name: Get yarn version from package.json
         run: |
           grep 'packageManager' package.json | awk -F: '{gsub(/[", ]/, "", $2); print $2}' | xargs -I {} echo "YARN_VERSION="{} >> "$GITHUB_ENV"
 
       # Set the yarn version by exporting to env var and output
-      - name: Set yarn version
+      - name: Append yarn version to $GITHUB_OUTPUT
         id: set_yarn_version
         run: |
           echo "yarn_version=${{ env.YARN_VERSION }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -43,7 +43,8 @@ on:
       - "packages/frontend/svelte.config.js"
 
   push:
-    branches: ["main", "staging", "dev"]
+    branches:
+      ["main", "staging", "dev", "48-retrieve-yarn-version-from-packagejson"]
     paths-ignore:
       # Ignore changes in documentation.
       - "docs/**"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -127,8 +127,7 @@ jobs:
       # Retrieve yarn version from package.json
       - name: Get yarn version
         run: |
-          echo "yarn_version=" >> "$GITHUB_ENV"
-          grep 'packageManager' package.json | awk -F: '{gsub(/[", ]/, "", $2); print $2}' | xargs -I {} echo "YARN_VERSION="{} >> "$GITHUB_ENV"
+          grep 'packageManager' package.json | awk -F: '{gsub(/[", ]/, "", $2); print $2}' | xargs -I {} echo "YARN_VERSION="{} >> $GITHUB_ENV
 
       # Set the yarn version by exporting to env var and output
       - name: Set yarn version

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -71,6 +71,7 @@ on:
       - ".env.example"
 
       # Ignore changes in backend package.
+      - ".github/workflows/backend.yml"
       - "packages/backend/**"
 
       # Ignore frontend package specific paths.

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Set yarn version
         id: set_yarn_version
         run: |
-          echo "yarn_version=${{ env.YARN_VERSION }}" >> "$GITHUB_ENV"
+          echo "yarn_version=${{ env.YARN_VERSION }}" >> $GITHUB_OUTPUT
 
         # Yarn installation
       - name: Enable corepack

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -92,16 +92,16 @@ jobs:
       - name: Check if production
         if: github.ref_name == 'production'
         run: |
-          echo "ENVIRONMENT_NAME=production" >> $GITHUB_ENV
+          echo "ENVIRONMENT_NAME=production" >> "$GITHUB_ENV"
       - name: Check if staging
         if: github.ref_name == 'staging'
         run: |
-          echo "ENVIRONMENT_NAME=staging" >> $GITHUB_ENV
+          echo "ENVIRONMENT_NAME=staging" >> "$GITHUB_ENV"
 
       - name: Check if development
         if: github.ref_name == 'dev'
         run: |
-          echo "ENVIRONMENT_NAME=development" >> $GITHUB_ENV
+          echo "ENVIRONMENT_NAME=development" >> "$GITHUB_ENV"
 
       # Original: https://magnussundstrom.se/blog/github-action-environment-check
       # Edited, due to: https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/
@@ -128,13 +128,13 @@ jobs:
       # Retrieve yarn version from package.json
       - name: Get yarn version
         run: |
-          grep 'packageManager' package.json | awk -F: '{gsub(/[", ]/, "", $2); print $2}' | xargs -I {} echo "YARN_VERSION="{} >> $GITHUB_ENV
+          grep 'packageManager' package.json | awk -F: '{gsub(/[", ]/, "", $2); print $2}' | xargs -I {} echo "YARN_VERSION="{} >> "$GITHUB_ENV"
 
       # Set the yarn version by exporting to env var and output
       - name: Set yarn version
         id: set_yarn_version
         run: |
-          echo "yarn_version=${{ env.YARN_VERSION }}" >> $GITHUB_OUTPUT
+          echo "yarn_version=${{ env.YARN_VERSION }}" >> "$GITHUB_OUTPUT"
 
         # Yarn installation
       - name: Enable corepack
@@ -154,7 +154,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: yarn-cache
@@ -202,7 +202,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: yarn-cache
@@ -264,7 +264,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: yarn-cache

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -1,0 +1,13 @@
+# Actions
+
+This discusses the actions section of the repository.
+
+## Commands
+
+What the hell is
+
+```shell
+grep 'packageManager' package.json | awk -F: '{gsub(/[", ]/, "", $2); print $2}' | xargs -I {} echo "YARN_VERSION="{} >> "$GITHUB_ENV"
+```
+
+Using the linux command line programs `grep` and `awk`, it retrieves the yarn version from the `package.json` file in the root directory. It then exports it to the environment variable `$GITHUB_ENV`


### PR DESCRIPTION
### Description

Minor refactoring to CI GitHub actions.

#### `package.json` package manager version retrieval

Instead of using an environment variable to set the `yarn` version, it now reads `package.json` and retrieves it using this CLI command:

```shell
grep 'packageManager' package.json | awk -F: '{gsub(/[", ]/, "", $2); print $2}' | xargs -I {} echo "YARN_VERSION="{} >> "$GITHUB_ENV"
```

The first half of the command, everything before `xargs`, retrieves the version. The second half exports the value to the job's environment variables.

#### Follow GitHub Actions documentation formatting for vars

In accordance with examples provided at GitHub actions documentation, GitHub workflow variables such as `$GITHUB_OUTPUT` and `$GITHUB_ENV` are now surrounded by parentheses.

Examples:

- https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs#example-defining-outputs-for-a-job
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-writing-an-environment-variable-to-github_env

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
