### PR TITLE
fix: change `slugify` sources

### DIFF
--- a/packages/backend/schemaTypes/series.ts
+++ b/packages/backend/schemaTypes/series.ts
@@ -20,7 +20,7 @@ export default defineType({
       title: 'Slug',
       type: 'slug',
       options: {
-        source: 'title',
+        source: 'name',
         maxLength: 200,
         slugify: (input: string) => slugValidator(input),
       },

--- a/packages/backend/schemaTypes/tag.ts
+++ b/packages/backend/schemaTypes/tag.ts
@@ -1,5 +1,6 @@
 import {TagIcon} from '@sanity/icons'
 import {defineField, defineType} from 'sanity'
+import slugValidator from '../lib/slugValidator'
 
 /**
  * A tag can be attached to an article. It lets us organize content into
@@ -24,9 +25,8 @@ export default defineType({
       title: 'Slug',
       type: 'slug',
       options: {
-        source: 'title',
+        source: 'name',
         maxLength: 200,
-        slugify: (input: string) => input.toLowerCase().replace(/\s+/g, '-').slice(0, 200),
       },
       validation: (rule) => rule.required(),
     }),

--- a/packages/backend/schemaTypes/tag.ts
+++ b/packages/backend/schemaTypes/tag.ts
@@ -27,6 +27,7 @@ export default defineType({
       options: {
         source: 'name',
         maxLength: 200,
+        slugify: (input: string) => slugValidator(input),
       },
       validation: (rule) => rule.required(),
     }),


### PR DESCRIPTION
### Description

- Changed slugify sources to match that of an object attribute actually present in the sanity document.
- Refactored `tag` document to use `slugValidator` function.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
