### PR TITLE
Image `alt` retrieval and implementation

### DIFF
--- a/packages/backend/schemaTypes/article.ts
+++ b/packages/backend/schemaTypes/article.ts
@@ -125,6 +125,13 @@ export default defineType({
       options: {
         hotspot: true,
       },
+      fields: [
+        {
+          name: 'alt',
+          type: 'string',
+          validation: (rule) => rule.required(),
+        },
+      ],
     }),
 
     defineField({
@@ -165,6 +172,25 @@ export default defineType({
         },
         {
           type: 'image',
+          fields: [
+            {
+              name: 'title',
+              title: 'Title',
+              type: 'string',
+            },
+            {
+              name: 'description',
+              title: 'Description',
+              type: 'text',
+              rows: 2,
+            },
+            {
+              name: 'alt',
+              title: 'Alt Text',
+              type: 'string',
+              validation: (rule) => rule.required(),
+            },
+          ],
         },
       ],
     }),

--- a/packages/backend/schemaTypes/member.ts
+++ b/packages/backend/schemaTypes/member.ts
@@ -97,6 +97,14 @@ export default defineType({
         hotspot: true,
       },
       description: 'Optional profile image, cropped when displayed on the website',
+      fields: [
+        {
+          title: 'Alt Text',
+          name: 'alt',
+          type: 'string',
+          validation: (rule) => rule.required(),
+        },
+      ],
     }),
 
     defineField({

--- a/packages/frontend/src/components/Image.svelte
+++ b/packages/frontend/src/components/Image.svelte
@@ -10,7 +10,7 @@
 	import type { ImageUrlBuilder } from 'sanity';
 
 	export let className = 'db';
-	export let alt = '';
+	export let altText = '';
 
 	export let media;
 	export let format: ImageFormat = 'webp';
@@ -30,4 +30,4 @@
 		.height(height);
 </script>
 
-<img src={Image.url()} {alt} class={className} />
+<img src={Image.url()} alt={altText} class={className} />

--- a/packages/frontend/src/components/article/DateLine.svelte
+++ b/packages/frontend/src/components/article/DateLine.svelte
@@ -1,9 +1,20 @@
 <script lang="ts">
 	import { dateFormatter } from '$lib/helpers';
+	import { onMount } from 'svelte';
+
+	let userAgent: Navigator;
+
+	// This is a workaround for the error "navigator is undefined"
+	onMount(() => {
+		userAgent = navigator;
+	});
 
 	export let date: string;
 </script>
 
 <p class="pa0 ma0 lh-copy tracked-02 fw4 f6">
-	<time datetime={date}>{dateFormatter(date, navigator.language)} UTC</time>
+	<!-- This is a workaround for "cannot read undefined" -->
+	{#if userAgent !== undefined}
+		<time datetime={date}>{dateFormatter(date, userAgent.language)} UTC</time>
+	{/if}
 </p>

--- a/packages/frontend/src/components/article/DateLine.svelte
+++ b/packages/frontend/src/components/article/DateLine.svelte
@@ -1,20 +1,10 @@
 <script lang="ts">
 	import { dateFormatter } from '$lib/helpers';
-	import { onMount } from 'svelte';
 
-	let userAgent: Navigator;
-
-	// This is a workaround for the error "navigator is undefined"
-	onMount(() => {
-		userAgent = navigator;
-	});
-
+	export let locale = 'en-US';
 	export let date: string;
 </script>
 
 <p class="pa0 ma0 lh-copy tracked-02 fw4 f6">
-	<!-- This is a workaround for "cannot read undefined" -->
-	{#if userAgent !== undefined}
-		<time datetime={date}>{dateFormatter(date, userAgent.language)} UTC</time>
-	{/if}
+	<time datetime={date}>{dateFormatter(date, locale)} UTC</time>
 </p>

--- a/packages/frontend/src/components/authorPage/Location.svelte
+++ b/packages/frontend/src/components/authorPage/Location.svelte
@@ -3,6 +3,10 @@
 	import type { From } from '$lib/sanity';
 
 	export let location: From;
+
+	// Locale determines the language the viewer sees the location in.
+	export let locale: string = 'en-US';
+
 	let flagEmoji: string;
 	let countryName: string;
 	let regionName: string;
@@ -10,7 +14,7 @@
 
 	if (location.country) {
 		flagEmoji = getFlagEmoji(location.country);
-		countryName = getCountryName(location.country, navigator.language)!;
+		countryName = getCountryName(location.country, locale) as string;
 	}
 
 	if (location.region) {

--- a/packages/frontend/src/components/home/ArticleBoxC.svelte
+++ b/packages/frontend/src/components/home/ArticleBoxC.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import Image from '$components/Image.svelte';
+	import type { Article } from '$lib/sanity';
 	import ByLine from './ByLine.svelte';
 	import DateLine from './DateLine.svelte';
 
-	export let article;
+	export let article: Article;
+	export let locale = 'en-US';
 </script>
 
 <a
@@ -26,7 +28,14 @@
 			</div>
 			{#if article.media}
 				<div class="pl3-ns order-1 order-2-ns mb4 mb0-ns w-100 w-40-l">
-					<Image media={article.media} width={480} height={320} quality={20} fit={'crop'} />
+					<Image
+						media={article.media}
+						width={480}
+						height={320}
+						quality={20}
+						fit={'crop'}
+						altText={article.media.alt}
+					/>
 				</div>
 			{/if}
 		</div>

--- a/packages/frontend/src/components/home/ArticleBoxC.svelte
+++ b/packages/frontend/src/components/home/ArticleBoxC.svelte
@@ -31,7 +31,7 @@
 			{/if}
 		</div>
 		<ByLine authors={article.authors} />
-		<DateLine date={article.date} />
+		<DateLine date={article.date} {locale} />
 	</article>
 </a>
 

--- a/packages/frontend/src/components/home/DateLine.svelte
+++ b/packages/frontend/src/components/home/DateLine.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { dateFormatter } from '$lib/helpers';
 
+	export let locale = 'en-US';
 	export let date: string;
 </script>
 
-<p class="f6 db gray pa0 ma0 fw4 lh-copy tracked-02">
-	<time datetime={date}>{dateFormatter(date, navigator.language)} UTC</time>
+<p class="pa0 ma0 lh-copy tracked-02 fw4 f6">
+	<time datetime={date}>{dateFormatter(date, locale)} UTC</time>
 </p>

--- a/packages/frontend/src/components/portabletext/ArticleImage.svelte
+++ b/packages/frontend/src/components/portabletext/ArticleImage.svelte
@@ -5,23 +5,22 @@
 </script>
 
 <figure class="ma2 mb4">
-	<!-- If there's a description, no need altText -->
-	{#if portableText.value.attrs.description}
-		<img
-			src={urlFor(portableText.value).fit('max').auto('format').url()}
-			alt={portableText.value.attrs.description}
-			loading="lazy"
-		/>
+	<img
+		src={urlFor(portableText.value).fit('max').auto('format').url()}
+		alt={portableText.value.alt}
+		loading="lazy"
+	/>
+	{#if portableText.value.title}
+		<h4 class="ph1 fw5 i ma0 mb3 mt2">{portableText.value.title}</h4>
 	{/if}
-	{#if portableText.value.attrs.title}
-		<h4 class="ph1 fw5 i ma0 mb3 mt2">{portableText.value.attrs.title}</h4>
-	{/if}
-	{#if portableText.value.attrs.description || portableText.value.attrs.creditLine}
+	{#if portableText.value.description || portableText.value.attrs.creditLine}
 		<figcaption class="fw5 f6 gray ph1">
 			<div class="flex flex-column">
-				<div>
-					{portableText.value.attrs.description}
-				</div>
+				{#if portableText.value.description}
+					<div>
+						{portableText.value.description}
+					</div>
+				{/if}
 				<div class="mt1">
 					<p class="pa0 ma0 i o-40">
 						Photo credit: {portableText.value.attrs.creditLine}
@@ -29,12 +28,6 @@
 				</div>
 			</div>
 		</figcaption>
-	{:else}
-		<img
-			src={urlFor(portableText.value).fit('max').auto('format').url()}
-			alt={portableText.value.attrs.altText}
-			loading="lazy"
-		/>
 	{/if}
 </figure>
 

--- a/packages/frontend/src/lib/sanity.ts
+++ b/packages/frontend/src/lib/sanity.ts
@@ -574,10 +574,30 @@ export interface Article {
 	category: Category;
 	tags: Tag[];
 	authors: Member[];
-	media: Image;
 	content: PortableTextBlock[];
-	headerImage: ImageAsset;
 	// content: PortableTextComponents[];
+
+	// headerImage and media both refer to the topmost
+	// image on an article. headerImage is queried in its
+	// own attribute because we need to obtain the
+	// `altText`, as well as the `creditLine`, both of
+	// which are not present in the sanity `ImageBuilder`
+	// package. Which is annoying. Therefore, the `ImageBuilder`
+	// takes the `media` attribute in the function
+	// signature, and the `altText` is retrieved from
+	// the headerImage attribute.
+	media: Image;
+	headerImage: HeaderImage;
+}
+
+/**
+ * HeaderImage exists because ImageAsset, for some reason,
+ * does not have an `altText` attribute. Hopefully, in
+ * the future, it receives one. For now, this must be
+ * implemented.
+ */
+export interface HeaderImage extends ImageAsset {
+	altText?: string;
 }
 
 export interface Image {

--- a/packages/frontend/src/lib/sanity.ts
+++ b/packages/frontend/src/lib/sanity.ts
@@ -75,7 +75,7 @@ export async function getHomepageArticles(): Promise<Article[]> {
 			category->{name},
 			authors[]->{name},
 			slug,
-			media
+			media,
 		}[0...10]`
 	);
 }
@@ -311,25 +311,16 @@ export async function getOneArticleFrom(where: string, what: string): Promise<Ar
 
 export async function getOneArticleFromCategory(where: string, what: string): Promise<Article> {
 	return await client.fetch(
-		// groq`*[_type == "article" && category->slug.current == $where && slug.current == $what][0]{
-		// 	title,
-		// 	subtitle,
-		// 	date,
-		// 	content,
-		// 	authors[]->{name},
-		// 	tags[]->{name},
-		// 	"headerImage": media.asset->{altText, description, url}
-		// }`,
 		groq`*[_type == "article" && category->slug.current == $where && slug.current == $what][0]{
 			title,
 			subtitle,
 			date,
 			content[]{
 				_type == "image" => {
+					title,
+					alt,
+					description,
 					"attrs": asset->{
-						altText,
-						title,
-						description,
 						metadata,
 						creditLine
 					},
@@ -508,7 +499,7 @@ export interface Member {
 	year?: number;
 	netid?: string;
 	bio?: string;
-	portrait?: ImageAsset;
+	portrait?: CustomImageAsset;
 	slug: Slug;
 	from: From;
 	handles: Handles;
@@ -587,7 +578,7 @@ export interface Article {
 	// signature, and the `altText` is retrieved from
 	// the headerImage attribute.
 	media: Image;
-	headerImage: HeaderImage;
+	headerImage: CustomImageAsset;
 }
 
 /**
@@ -596,8 +587,8 @@ export interface Article {
  * the future, it receives one. For now, this must be
  * implemented.
  */
-export interface HeaderImage extends ImageAsset {
-	altText?: string;
+export interface CustomImageAsset extends ImageAsset {
+	alt: string;
 }
 
 export interface Image {
@@ -606,4 +597,7 @@ export interface Image {
 		_ref: string;
 		_type: string;
 	};
+	title?: string;
+	description?: string;
+	alt: string;
 }

--- a/packages/frontend/src/routes/(app)/about/staff/[name]/+page.svelte
+++ b/packages/frontend/src/routes/(app)/about/staff/[name]/+page.svelte
@@ -39,7 +39,7 @@
 				<div class="mb2">
 					<h2 class="fw6 tracked f7 sans gray">FROM</h2>
 				</div>
-				<Location {location} />
+				<Location {location} locale={data.chosenLocale} />
 			</div>
 		{/if}
 		{#if handles}
@@ -90,7 +90,7 @@
 				{#each articles as article}
 					<!-- #key is a fix for https://github.com/onmagnoliasquare/website/issues/96  -->
 					{#key article}
-						<ArticleBoxC {article} />
+						<ArticleBoxC {article} locale={data.chosenLocale} />
 					{/key}
 				{/each}
 			</ul>

--- a/packages/frontend/src/routes/(app)/about/staff/[name]/+page.svelte
+++ b/packages/frontend/src/routes/(app)/about/staff/[name]/+page.svelte
@@ -3,7 +3,6 @@
 	import ContactIcons from '$components/general/ContactIcons.svelte';
 	import ArticleBoxC from '$components/home/ArticleBoxC.svelte';
 	import Image from '$components/Image.svelte';
-	import { getCountryName, getFlagEmoji } from '$lib/helpers';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
@@ -18,7 +17,14 @@
 	<header class="mt4 mb3-l mb2 pa2 pa4-l flex flex-column w-100 w-30-ns pr3-l order-2 order-1-ns">
 		{#if member.portrait}
 			<div class="w-100">
-				<Image media={member.portrait} width={250} height={250} fit={'crop'} quality={80} />
+				<Image
+					media={member.portrait}
+					width={250}
+					height={250}
+					fit={'crop'}
+					quality={80}
+					altText={member.portrait.alt}
+				/>
 			</div>
 		{/if}
 		<div class="w-100 mb4">

--- a/packages/frontend/src/routes/(app)/category/[category=categories]/[slug]/+page.svelte
+++ b/packages/frontend/src/routes/(app)/category/[category=categories]/[slug]/+page.svelte
@@ -85,11 +85,11 @@
 						<ByLine authors={data.article.authors} />
 					</div>
 					<div class="gray tracked-02">
-						<DateLine date={data.article.date} />
+						<DateLine date={data.article.date} locale={data.chosenLocale} />
 					</div>
 					<div class="gray tracked-02 f6">
 						updated
-						<DateLine date={data.article.updatedDate} />
+						<DateLine date={data.article.updatedDate} locale={data.chosenLocale} />
 					</div>
 				</div>
 			{:else}

--- a/packages/frontend/src/routes/(app)/category/[category=categories]/[slug]/+page.svelte
+++ b/packages/frontend/src/routes/(app)/category/[category=categories]/[slug]/+page.svelte
@@ -17,36 +17,10 @@
 	import { fly } from 'svelte/transition';
 
 	export let data: PageData;
-	// let headerImageURL: string;
-	// if (data.article.headerImage) {
-	// 	// This retrieves a web-optimized version (`.webp` format)
-	// 	// of the image asset.
-	// 	// See: https://www.sanity.io/docs/image-urls#auto-777d41f23d56
-	// 	headerImageURL = data.article.headerImage.url.concat('?auto=format&fit=max');
-	// }
 </script>
 
 <article class="pa1 pa3-ns">
 	<header>
-		<!-- <div
-			class="vh-100 dt w-100 tc bg-dark-gray white cover"
-			style={`background:url(${urlFor(data.article.media).format('webp').fit('max').url()}) no-repeat center center fixed; background-size: cover; filter: brightness(70%);`}
-		>
-			<div class="dtc v-mid pa2">
-				<h1 class="f2 f-subheadline-l fw2 tracked-tight pa0 ma0 mw9 white">
-					<span class="bg-black-90 lh-copy white pa3">
-						{data.article.title}
-					</span>
-				</h1>
-				{#if data.article.subtitle}
-					<p
-						class="serif fw2 i f4-ns f2-l tracked-tight-1-ns lh-title pa2 ma0 mb3 measure mt4 white-80"
-					>
-						{data.article.subtitle}
-					</p>
-				{/if}
-			</div>
-		</div> -->
 		<div class="flex justify-center">
 			<div class="center mw7">
 				{#if data.article.title}
@@ -67,7 +41,10 @@
 			{#if data.article.media}
 				<figure class="ma0 mb4">
 					<!-- TODO THIS NEEDS AN ALT TEXT -->
-					<img src={urlFor(data.article.media).format('webp').fit('max').url()} alt="" />
+					<img
+						src={urlFor(data.article.media).format('webp').fit('max').url()}
+						alt={data.article.media.alt}
+					/>
 					{#if data.article.headerImage.creditLine}
 						<figcaption class="fw5 f6 gray ph1">
 							<div class="mt1">

--- a/packages/frontend/src/routes/(home)/+page.svelte
+++ b/packages/frontend/src/routes/(home)/+page.svelte
@@ -16,12 +16,12 @@
 		<div class="flex flex-column flex-row-l">
 			<div class="pa4-ns w-100 w-50-l">
 				{#each data.articles.slice(1, 5) as article}
-					<ArticleBoxC {article} />
+					<ArticleBoxC {article} locale={data.chosenLocale} />
 				{/each}
 			</div>
 			<div class="pa4-ns w-100 w-50-l">
 				{#each data.articles.slice(5, 10) as article}
-					<ArticleBoxC {article} />
+					<ArticleBoxC {article} locale={data.chosenLocale} />
 				{/each}
 			</div>
 		</div>

--- a/packages/frontend/src/routes/+layout.server.ts
+++ b/packages/frontend/src/routes/+layout.server.ts
@@ -1,0 +1,8 @@
+import type { LayoutServerLoad } from './$types';
+
+// Retrieved from: https://poly-i18n.vercel.app/en/kitbook/docs/3-use-with-sveltekit
+export const load: LayoutServerLoad = ({ cookies, request }) => {
+	const acceptedLanguage = request.headers.get('accept-language')?.split(',')[0].trim();
+	const chosenLocale = cookies.get('locale');
+	return { acceptedLanguage, chosenLocale };
+};


### PR DESCRIPTION
### Description

All pictures now have alt text attributes. This required some restructuring of the backend documents, for articles and members, as well as frontend adjustments to queries.

#### Backend

- Added `alt`, `description`, and `title` fields to `member.ts` and `article.ts`, since these have media content. **Addition of these fields to future documents that have media content will need to be added as well.**

#### Frontend

- Restructured/simplified queries so they retrieve the new backend document attributes.
- Removed `navigator` references which caused a bug. On reload, the site would send a 500 error code when trying to access user locale. This was because `navigator` data was attempted to render on the server. `navigator` is client side only. See 79d21f474b786b14fb01c1d678cd57ca53e1078d.
- Implemented `alt` additions to `<img>` elements.

Closes #120 

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
