### PR TITLE
Add related articles on article page

### DIFF
--- a/packages/frontend/src/lib/sanity.ts
+++ b/packages/frontend/src/lib/sanity.ts
@@ -495,13 +495,13 @@ export async function getMember(slug: string): Promise<Member> {
 }
 
 export async function getRecommendedArticles(
-	fetched_num: number = 9,
-	desired_return_num: number = 3,
 	series: string,
 	currentArticle: string,
 	member: string,
 	articleTag: string,
-	category: string
+	category: string,
+	fetched_num: number = 9,
+	desired_return_num: number = 3
 ): Promise<Article[]> {
 	const uniqueArticles: Set<Article> = new Set<Article>();
 	const returnedArticles: Article[] = [];

--- a/packages/frontend/src/routes/(app)/category/[category=categories]/[slug]/+page.server.ts
+++ b/packages/frontend/src/routes/(app)/category/[category=categories]/[slug]/+page.server.ts
@@ -1,6 +1,11 @@
 import { error, type ServerLoadEvent } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import { type Article, getOneArticleFromCategory } from '$lib/sanity';
+import {
+	type Article,
+	getOneArticleFromCategory,
+	getOneArticleFromSeries,
+	getRecommendedArticles
+} from '$lib/sanity';
 
 export const load: PageServerLoad = (async (event: ServerLoadEvent) => {
 	const { category, slug } = event.params;
@@ -8,14 +13,24 @@ export const load: PageServerLoad = (async (event: ServerLoadEvent) => {
 		(category as string).toLowerCase(),
 		slug as string
 	);
+
 	const title = article.title;
 
+	let relatedArticles: Article[];
+
 	if (article) {
+		relatedArticles = await getRecommendedArticles(
+			article.series.slug.current as string,
+			article.title as string,
+			article.authors[0].slug.current as string,
+			article.tags[0].slug.current as string,
+			article.category.slug.current as string
+		);
 		return {
 			article,
-			title
+			title,
+			relatedArticles
 		};
 	}
-
 	throw error(404, 'Not found');
 }) satisfies PageServerLoad;


### PR DESCRIPTION
Ideally (if this works), this function should get an array of articles according to the series, author, tag and category of the current article. And return 3 unique articles that are related.

### Description
Added a new function in `sanity.ts` called `getRecommendedArticles`, it takes the arguments of `number of articles to add to an array`, `number of articles to return`, `current article series`, `current article name`, `current article author`, `current article tag` and `current article category`.  

I'm really unsure if the `order` function to sort the array (to display articles in the same series first) was initialized correctly, as well as whether I'm processing variable types correctly.

**Tests have not been run.**

Requested Neo to check out the code.

### Checklist

- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
