### PR TITLE
Make hyperlinks purple

### DIFF
--- a/packages/frontend/src/styles/onmagnoliasquare.css
+++ b/packages/frontend/src/styles/onmagnoliasquare.css
@@ -10407,7 +10407,7 @@ h6 {
     --link-color: var(--light-yellow);
     --red-color: var(--bg-color);
     --border-color: var(--text-color);
-    --article-link-color: var(--green);
+    --article-link-color: var(--light-purple);
   }
 }
 


### PR DESCRIPTION
### Description

Refactored `--article-link-color` under `/src/styles/onmagnoliasquare.css`  from `--green` to `--light-purple`.
### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
