### PR TITLE
refactor(f): make hyperlinks purple in light mode

### DIFF
--- a/packages/frontend/src/styles/onmagnoliasquare.css
+++ b/packages/frontend/src/styles/onmagnoliasquare.css
@@ -10396,7 +10396,7 @@ h6 {
   --bg-color: var(--white);
   --link-color: var(--gold);
   --red-color: var(--dark-red);
-  --article-link-color: var(--dark-green);
+  --article-link-color: var(--purple);
   --white: #fff;
 }
 


### PR DESCRIPTION
### Description

Hyperlinks will now render in --purple instead of --dark-green when the webpage is in light mode

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
