### PR TITLE
Implement Spotify embedding

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "prettier-plugin-svelte": "^3.2.7",
     "svelte": "^5.1.9",
     "svelte-check": "^4.0.5",
+    "sveltekit-embed": "^0.0.18",
     "tslib": "^2.8.1",
     "typescript": "^5.6.3",
     "vite": "^5.4.10",

--- a/packages/backend/schemaTypes/article.ts
+++ b/packages/backend/schemaTypes/article.ts
@@ -196,6 +196,9 @@ export default defineType({
             },
           ],
         },
+        {
+          type: 'embeddedLink',
+        },
       ],
     }),
 

--- a/packages/backend/schemaTypes/index.ts
+++ b/packages/backend/schemaTypes/index.ts
@@ -2,6 +2,7 @@ import article from './article'
 import category from './category'
 import member from './member'
 import blockContent from './objects/blockContent'
+import embeddedLink from './objects/embeddedLink'
 import fromLocation from './objects/fromLocation'
 import socialHandles from './objects/socialHandles'
 import series from './series'
@@ -11,6 +12,7 @@ export const schemaTypes = [
   socialHandles,
   blockContent,
   fromLocation,
+  embeddedLink,
   article,
   member,
   category,

--- a/packages/backend/schemaTypes/objects/embeddedLink.ts
+++ b/packages/backend/schemaTypes/objects/embeddedLink.ts
@@ -1,0 +1,19 @@
+import {InlineElementIcon} from '@sanity/icons'
+import {defineType} from 'sanity'
+
+export default defineType({
+  type: 'object',
+  name: 'embeddedLink',
+  title: 'Embed',
+  icon: InlineElementIcon,
+  description: 'An embedded, stylized link embedded on a webpage.',
+  fields: [
+    {
+      title: 'Content URL',
+      name: 'contentUrl',
+      description: 'Share URL of the content from the site to embed.',
+      type: 'url',
+      validation: (rule) => rule.required(),
+    },
+  ],
+})

--- a/packages/frontend/src/components/embeds/EmbeddedLink.svelte
+++ b/packages/frontend/src/components/embeds/EmbeddedLink.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { parseEmbedLink } from '$lib/helpers';
+	import SpotifyEmbed from './SpotifyEmbed.svelte';
+
+	interface Props {
+		portableText: any;
+	}
+
+	let { portableText }: Props = $props();
+
+	let link = parseEmbedLink(portableText.value.contentUrl);
+</script>
+
+{#if link.name == 'spotify'}
+	<SpotifyEmbed spotifyPath={link.path!} />
+{/if}

--- a/packages/frontend/src/components/embeds/SpotifyEmbed.svelte
+++ b/packages/frontend/src/components/embeds/SpotifyEmbed.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { Spotify } from 'sveltekit-embed';
+
+	interface Props {
+		spotifyPath: string;
+	}
+
+	let { spotifyPath }: Props = $props();
+</script>
+
+<div>
+	<Spotify spotifyLink={spotifyPath} />
+</div>

--- a/packages/frontend/src/index.test.ts
+++ b/packages/frontend/src/index.test.ts
@@ -1,7 +1,25 @@
 import { dateFormatter, hasUppercase } from '$lib';
 import { describe, it, expect, test } from 'vitest';
 import createSiteTitle from '$lib/createSiteTitle';
+import { parseEmbedLink } from '$lib/helpers';
 
+describe('parseEmbedLink', () => {
+	it('extracts spotify name, given a valid link', () => {
+		expect(
+			parseEmbedLink('https://open.spotify.com/album/5zi7WsKlIiUXv09tbGLKsE?si=28a6cae09d214cc6')
+				.name
+		).toBe('spotify');
+	});
+
+	it('extracts spotify path, given a valid link', () => {
+		expect(
+			parseEmbedLink('https://open.spotify.com/album/5zi7WsKlIiUXv09tbGLKsE?si=28a6cae09d214cc6')
+				.path
+		).toBe('album/5zi7WsKlIiUXv09tbGLKsE?si=28a6cae09d214cc6');
+	});
+});
+
+//
 describe('hasUppercase', () => {
 	it('is true for uppercase', () => {
 		expect(hasUppercase('abcDefg')).toBe(true);

--- a/packages/frontend/src/index.test.ts
+++ b/packages/frontend/src/index.test.ts
@@ -17,9 +17,20 @@ describe('parseEmbedLink', () => {
 				.path
 		).toBe('album/5zi7WsKlIiUXv09tbGLKsE?si=28a6cae09d214cc6');
 	});
+
+	it('is URL for .name for erroneous link', () => {
+		expect(
+			parseEmbedLink('https://open.tokify.com/nonsense/album/5zi7WsKlIiUXv09tbGLKsEsicc6').name
+		).toBe('https://open.tokify.com/nonsense/album/5zi7WsKlIiUXv09tbGLKsEsicc6');
+	});
+
+	it('is URL for .path for erroneous link', () => {
+		expect(
+			parseEmbedLink('https://open.tokify.com/nonsense/album/5zi7WsKlIiUXv09tbGLKsEsicc6').path
+		).toBe('https://open.tokify.com/nonsense/album/5zi7WsKlIiUXv09tbGLKsEsicc6');
+	});
 });
 
-//
 describe('hasUppercase', () => {
 	it('is true for uppercase', () => {
 		expect(hasUppercase('abcDefg')).toBe(true);

--- a/packages/frontend/src/lib/helpers.ts
+++ b/packages/frontend/src/lib/helpers.ts
@@ -125,6 +125,14 @@ export const parseEmbedLink = (url: string): EmbeddedLinkAttributes => {
 	// Search the string for a name from the list of domain names.
 	let match = url.match(name)!;
 
+	// If there's no match...
+	if (!match) {
+		return {
+			name: url,
+			path: url
+		};
+	}
+
 	// switch statements are faster than 'if'.
 	switch (match[0]) {
 		case 'anchorfm':
@@ -140,7 +148,7 @@ export const parseEmbedLink = (url: string): EmbeddedLinkAttributes => {
 			return {
 				name: match[0],
 
-				// extracts the last part of the spotify URL.
+				// Extracts the last part of the spotify URL.
 				path: url.split('/').slice(-2).join('/')
 			};
 		case 'stackblitz':

--- a/packages/frontend/src/lib/helpers.ts
+++ b/packages/frontend/src/lib/helpers.ts
@@ -99,3 +99,102 @@ export const getCountryName = (countryCode: string, locale: string): string | un
 	let name = new Intl.DisplayNames([locale], { type: 'region' });
 	return name.of(countryCode);
 };
+
+/**
+ * parseEmbedLink returns a string that is usable by the
+ * dependency `sveltekit-embed`. The dependency exposes
+ * multiple components that accept links to embed embedded
+ * content from different sources, like Spotify. The components
+ * require the strings to be chopped in a certain style.
+ * This function returns this formatting. See:
+ * https://sveltekit-embed.pages.dev/. In the future, there may
+ * be updates to URL domains and paths. I really hope this does
+ * not happen, and I doubt it will. Any sane company will not do
+ * this unless absolutely necessary.
+ * @param url given URL, retrieved from Sanity
+ * @returns `string` formatted link
+ */
+export const parseEmbedLink = (url: string): EmbeddedLinkAttributes => {
+	// This builds a long string of `or` boolean expressions for
+	// `RegExp()` parameter input.
+	const domainNames = sourcesList.join('|');
+
+	// Defines the regex expression to seek for what we want.
+	const name = new RegExp(`(${domainNames})(\/*)?`, 'i');
+
+	// Search the string for a name from the list of domain names.
+	let match = url.match(name)!;
+
+	// switch statements are faster than 'if'.
+	switch (match[0]) {
+		case 'anchorfm':
+		case 'buzzsprout':
+		case 'codepen':
+		case 'deezer':
+		case 'gist':
+		case 'guild':
+		case 'relive':
+		case 'simplecast':
+		case 'slides':
+		case 'spotify':
+			return {
+				name: match[0],
+
+				// extracts the last part of the spotify URL.
+				path: url.split('/').slice(-2).join('/')
+			};
+		case 'stackblitz':
+
+		/**
+		 * TikTok requires the extraction of the `webid`, which
+		 * is just a query in the URL. The very last part.
+		 */
+		case 'tiktok':
+		case 'toot':
+		case 'tweet':
+		case 'vimeo':
+		case 'youtube':
+		case 'zencastr':
+		case 'soundcloud':
+		case 'genericembed':
+		default:
+			return {
+				name: url,
+				path: url
+			};
+	}
+};
+
+interface EmbeddedLinkAttributes {
+	name?: string;
+	path?: string;
+}
+
+/**
+ * These are the sources supported by `sveltekit-embed`.
+ * Notice the lack of `instagram`. Instagram, or more
+ * specifically Meta, requires their own API verification to
+ * use their embed API.
+ */
+export const sourcesList = [
+	'anchorfm',
+	'bluesky',
+	'buzzsprout',
+	'codepen',
+	'deezer',
+	'genericembed',
+	'gist',
+	'guild',
+	'relive',
+	'simplecast',
+	'slides',
+	'soundcloud',
+	'spotify',
+	'stackblitz',
+	'tiktok',
+	'toot',
+	'tweet',
+	'vimeo',
+	'youtube',
+	'zencastr'
+];

--- a/packages/frontend/src/lib/sanity.ts
+++ b/packages/frontend/src/lib/sanity.ts
@@ -602,3 +602,9 @@ export interface Image {
 	description?: string;
 	alt: string;
 }
+
+export interface EmbeddedLink {
+	_type: string;
+	_key: string;
+	contentUrl: string;
+}

--- a/packages/frontend/src/routes/(app)/category/[category=categories]/[slug]/+page.svelte
+++ b/packages/frontend/src/routes/(app)/category/[category=categories]/[slug]/+page.svelte
@@ -4,6 +4,7 @@
 	import DateLine from '$components/article/DateLine.svelte';
 	import ArticleBodyList from '$components/portabletext/ArticleBodyList.svelte';
 	import ArticleBodyListItem from '$components/portabletext/ArticleBodyListItem.svelte';
+	import EmbeddedLink from '$components/embeds/EmbeddedLink.svelte';
 	import ArticleLink from '$components/portabletext/ArticleLink.svelte';
 	import NormalCentering from '$components/NormalCentering.svelte';
 	import { urlFor } from '$lib/sanity';
@@ -99,7 +100,8 @@
 					},
 					block: ArticleSingleArticleBlock,
 					types: {
-						image: ArticleImage
+						image: ArticleImage,
+						embeddedLink: EmbeddedLink
 					},
 					list: ArticleBodyList,
 					listItem: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14378,6 +14378,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sveltekit-embed@npm:^0.0.18":
+  version: 0.0.18
+  resolution: "sveltekit-embed@npm:0.0.18"
+  peerDependencies:
+    svelte: ^4.0.0 || ^5.0.0
+  checksum: 10c0/9bd73b2d2fbff82b52fb92ed2d579ea30c144bf7fbf05c379984e1c37e4f6fc0834f2c7624d5607798e12ed661c546706a622473ce97e54a44834cfb906ce039
+  languageName: node
+  linkType: hard
+
 "symbol-tree@npm:^3.2.4":
   version: 3.2.4
   resolution: "symbol-tree@npm:3.2.4"
@@ -15453,6 +15462,7 @@ __metadata:
     styled-components: "npm:^6.1.13"
     svelte: "npm:^5.1.9"
     svelte-check: "npm:^4.0.5"
+    sveltekit-embed: "npm:^0.0.18"
     tslib: "npm:^2.8.1"
     typescript: "npm:^5.6.3"
     vite: "npm:^5.4.10"


### PR DESCRIPTION
### Description

Implemented proper Spotify embedding using dependency [`sveltekit-embed`](https://github.com/spences10/sveltekit-embed).

- Implemented new type `embeddedLink` in backend and frontend.
- Embedded link rendering on frontend article page.
- Added `parseEmbedLink` function that is extensible into the future for more link types.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
