### PR TITLE
Add `committee` schemaType to sanity backend

### DIFF
--- a/packages/backend/schemaTypes/committee.ts
+++ b/packages/backend/schemaTypes/committee.ts
@@ -1,0 +1,48 @@
+import {FolderIcon} from '@sanity/icons'
+import {defineField, defineType} from 'sanity'
+import slugValidator from '../lib/slugValidator'
+
+export default defineType({
+  name: 'committee',
+  title: 'Committee',
+  type: 'document',
+  icon: FolderIcon,
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Committee Name',
+      type: 'string',
+      validation: (rule) => rule.required(),
+    }),
+
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: {
+        source: 'name',
+        maxLength: 200,
+        slugify: (input: string) => slugValidator(input),
+      },
+      validation: (rule) => rule.required(),
+    }),
+
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'text',
+      description: 'Information about the committee.',
+      //@ts-ignore TS(2353)
+      rows: 4,
+      validation: (rule) => rule.required(),
+    }),
+
+    defineField({
+      name: 'useCustomCss',
+      title: 'Use Custom CSS',
+      description:
+        'Enable if Custom CSS has been designed for this specific article and is ready on the frontend for use. If no custom CSS is applied, default styling will be used.',
+      type: 'boolean',
+    }),
+  ],
+})

--- a/packages/backend/schemaTypes/index.ts
+++ b/packages/backend/schemaTypes/index.ts
@@ -7,6 +7,7 @@ import fromLocation from './objects/fromLocation'
 import socialHandles from './objects/socialHandles'
 import series from './series'
 import tag from './tag'
+import committee from './committee'
 
 export const schemaTypes = [
   socialHandles,
@@ -18,4 +19,5 @@ export const schemaTypes = [
   category,
   series,
   tag,
+  committee,
 ]

--- a/packages/backend/schemaTypes/member.ts
+++ b/packages/backend/schemaTypes/member.ts
@@ -1,5 +1,5 @@
 import {UserIcon} from '@sanity/icons'
-import {defineField, defineType} from 'sanity'
+import {defineField, defineType, defineArrayMember} from 'sanity'
 import slugValidator from '../lib/slugValidator'
 
 /**
@@ -45,6 +45,20 @@ export default defineType({
 
       // The only valid inputs would be the organization's founding up to the current year.
       validation: (rule) => rule.integer().min(2013).max(new Date().getFullYear()),
+    }),
+
+    defineField({
+      name: 'committee',
+      title: 'Committee',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          name: 'committee',
+          title: 'Committee',
+          type: 'reference',
+          to: [{type: 'committee'}],
+        }),
+      ],
     }),
 
     defineField({


### PR DESCRIPTION
### Description

- Add the schema type `committee` in `backend`
- Implement an optional selection of `committee` under `member page` in `Sanity`
- We can use this info for `Staff Page Sorting`

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
