### PR TITLE
163 implement copy paste plugin in sanity

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@sanity/icons": "^3.4.0",
     "@sanity/image-url": "^1.1.0",
     "@sanity/vision": "^3.62.3",
+    "@superside-oss/sanity-plugin-copy-paste": "^1.0.3",
+    "archiver-utils": "^5.0.2",
     "groq": "^3.62.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/backend/sanity.config.ts
+++ b/packages/backend/sanity.config.ts
@@ -1,4 +1,5 @@
 import {defineConfig} from 'sanity'
+import {copyPastePlugin} from '@superside-oss/sanity-plugin-copy-paste'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
 import {schemaTypes} from './schemaTypes'
@@ -24,6 +25,7 @@ export default defineConfig([
           enabled: true,
         },
       }),
+      copyPastePlugin(),
     ],
 
     schema: {

--- a/packages/backend/schemaTypes/article.ts
+++ b/packages/backend/schemaTypes/article.ts
@@ -2,6 +2,7 @@ import {ComposeIcon, DocumentsIcon, ImageIcon, InfoOutlineIcon, TagsIcon} from '
 import {defineArrayMember, defineField, defineType} from 'sanity'
 import slugValidator from '../lib/slugValidator'
 import abbreviateName from '../lib/abbreviateName'
+import {copyPaste} from '@superside-oss/sanity-plugin-copy-paste'
 
 // Portable text editor configuration on Sanity docs:
 // https://www.sanity.io/docs/portable-text-editor-configuration
@@ -225,6 +226,7 @@ export default defineType({
       type: 'boolean',
       group: 'info',
     }),
+    defineField(copyPaste),
   ],
 
   initialValue: {

--- a/packages/backend/schemaTypes/category.ts
+++ b/packages/backend/schemaTypes/category.ts
@@ -1,6 +1,7 @@
 import {FolderIcon} from '@sanity/icons'
 import {defineField, defineType} from 'sanity'
 import slugValidator from '../lib/slugValidator'
+import {copyPaste} from '@superside-oss/sanity-plugin-copy-paste'
 
 /**
  * A category defines the navbar headings on the website. It also defines their
@@ -47,6 +48,7 @@ export default defineType({
         'Enable if Custom CSS has been designed for this specific article and is ready on the frontend for use. If no custom CSS is applied, default styling will be used.',
       type: 'boolean',
     }),
+    defineField(copyPaste),
   ],
   preview: {
     select: {

--- a/packages/backend/schemaTypes/committee.ts
+++ b/packages/backend/schemaTypes/committee.ts
@@ -1,6 +1,7 @@
 import {FolderIcon} from '@sanity/icons'
 import {defineField, defineType} from 'sanity'
 import slugValidator from '../lib/slugValidator'
+import {copyPaste} from '@superside-oss/sanity-plugin-copy-paste'
 
 export default defineType({
   name: 'committee',
@@ -42,6 +43,7 @@ export default defineType({
         'Enable if Custom CSS has been designed for this specific article and is ready on the frontend for use. If no custom CSS is applied, default styling will be used.',
       type: 'boolean',
     }),
+    defineField(copyPaste),
   ],
   preview: {
     select: {

--- a/packages/backend/schemaTypes/member.ts
+++ b/packages/backend/schemaTypes/member.ts
@@ -1,6 +1,7 @@
 import {UserIcon} from '@sanity/icons'
 import {defineField, defineType} from 'sanity'
 import slugValidator from '../lib/slugValidator'
+import {copyPaste} from '@superside-oss/sanity-plugin-copy-paste'
 
 /**
  * A "member" is someone who produces content for our organization.
@@ -119,6 +120,7 @@ export default defineType({
       description: 'Optional usernames for social platforms.',
       type: 'handles',
     }),
+    defineField(copyPaste),
   ],
   preview: {
     select: {

--- a/packages/backend/schemaTypes/series.ts
+++ b/packages/backend/schemaTypes/series.ts
@@ -1,6 +1,7 @@
 import {FolderIcon} from '@sanity/icons'
 import {defineField, defineType} from 'sanity'
 import slugValidator from '../lib/slugValidator'
+import {copyPaste} from '@superside-oss/sanity-plugin-copy-paste'
 
 export default defineType({
   name: 'series',
@@ -42,6 +43,7 @@ export default defineType({
         'Enable if Custom CSS has been designed for this specific article and is ready on the frontend for use. If no custom CSS is applied, default styling will be used.',
       type: 'boolean',
     }),
+    defineField(copyPaste),
   ],
   preview: {
     select: {

--- a/packages/backend/schemaTypes/tag.ts
+++ b/packages/backend/schemaTypes/tag.ts
@@ -1,6 +1,7 @@
 import {TagIcon} from '@sanity/icons'
 import {defineField, defineType} from 'sanity'
 import slugValidator from '../lib/slugValidator'
+import {copyPaste} from '@superside-oss/sanity-plugin-copy-paste'
 
 /**
  * A tag can be attached to an article. It lets us organize content into
@@ -39,6 +40,7 @@ export default defineType({
       //@ts-ignore TS(2353)
       rows: 4,
     }),
+    defineField(copyPaste),
   ],
   preview: {
     select: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3273,7 +3273,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sanity/ui@npm:^1.9.3":
+"@sanity/ui@npm:^1.3.0, @sanity/ui@npm:^1.9.3":
   version: 1.9.3
   resolution: "@sanity/ui@npm:1.9.3"
   dependencies:
@@ -3479,6 +3479,21 @@ __metadata:
   dependencies:
     "@sentry/types": "npm:8.37.1"
   checksum: 10c0/04d6ece0713d686028c8ab9fe9c082cf611365620010b2777f4dd2b41da7cbc9bcede5e9581e6569062bf5165f8a3f7602dfefd72ea73185bd57f16aeca6642a
+  languageName: node
+  linkType: hard
+
+"@superside-oss/sanity-plugin-copy-paste@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@superside-oss/sanity-plugin-copy-paste@npm:1.0.3"
+  dependencies:
+    "@sanity/incompatible-plugin": "npm:^1.0.4"
+    "@sanity/ui": "npm:^1.3.0"
+    nanoid: "npm:^4.0.1"
+    react-icons: "npm:^4.8.0"
+  peerDependencies:
+    react: ^18
+    sanity: ^3
+  checksum: 10c0/6315d4400a1fab7a411bca350b5ebcb69d4f6482472c3a88f7ffad2452b4e77ee7820800ff9e7e05a1ddc313d8f2cbd8cf236bad7a2f8d85d869d386682b7c45
   languageName: node
   linkType: hard
 
@@ -9762,6 +9777,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "nanoid@npm:4.0.2"
+  bin:
+    nanoid: bin/nanoid.js
+  checksum: 10c0/3fec62f422bc4727918eda0e7aa43e9cbb2e759be72813a0587b9dac99727d3c7ad972efce7f4f1d4cb5c7c554136a1ec3b1043d1d91d28d818d6acbe98200e5
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^5.0.7":
   version: 5.0.8
   resolution: "nanoid@npm:5.0.8"
@@ -10965,6 +10989,15 @@ __metadata:
     react-native:
       optional: true
   checksum: 10c0/95f07b73760a089a57584107ba8c02657fabaf250bff837bc9c650aaa4c0f57c65546190348ae08dee3c51ba81bcefc2a700212b1a1d03ff0d7a299f88be402a
+  languageName: node
+  linkType: hard
+
+"react-icons@npm:^4.8.0":
+  version: 4.12.0
+  resolution: "react-icons@npm:4.12.0"
+  peerDependencies:
+    react: "*"
+  checksum: 10c0/2170f43031ee7365539f72d4075cbe6c7fbf9a66d6cf4494aa9393b194272da0564f5b19d1b24dbfc567c0ac89f5fe5b8974d92dd83f61e252388dde6a226fb8
   languageName: node
   linkType: hard
 
@@ -13780,6 +13813,7 @@ __metadata:
     "@sanity/icons": "npm:^3.4.0"
     "@sanity/image-url": "npm:^1.1.0"
     "@sanity/vision": "npm:^3.62.3"
+    "@superside-oss/sanity-plugin-copy-paste": "npm:^1.0.3"
     "@sveltejs/adapter-auto": "npm:^3.3.1"
     "@sveltejs/adapter-cloudflare": "npm:^4.7.4"
     "@sveltejs/kit": "npm:^2.7.4"
@@ -13792,6 +13826,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.12.2"
     "@vitest/coverage-v8": "npm:^2.1.4"
     "@vitest/ui": "npm:^2.1.4"
+    archiver-utils: "npm:^5.0.2"
     eslint: "npm:^9.14.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-svelte: "npm:^2.46.0"


### PR DESCRIPTION
### Description
Modified `package.json` to include copy-paste plugin for Sanity. Implemented it into `articles`, `committees`, `members`, `tags`, `series`, `categories` schematypes.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
