### PR TITLE
Update unit and integration testing

### DIFF
--- a/packages/frontend/.prettierignore
+++ b/packages/frontend/.prettierignore
@@ -6,7 +6,7 @@ yarn.lock
 
 # === Directories ===
 # These are directories that contain files that
-# are either output from proceses or are library
+# are either output from processes or are library
 # dependencies.
 .svelte-kit
 node_modules

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -14,7 +14,7 @@
 		"test:unit": "run -T vitest",
 		"test:ci": "run -T vitest run",
 		"test:ci-no-pool": "run -T vitest run --pool forks --poolOptions.forks.singleFork",
-		"test:ui": "run -T vitest --ui",
+		"test:ui": "run -T vitest --ui && run -T playwright test --ui",
 		"coverage": "run -T vitest run --coverage"
 	},
 	"type": "module"

--- a/packages/frontend/src/components.test.svelte.ts
+++ b/packages/frontend/src/components.test.svelte.ts
@@ -1,0 +1,52 @@
+/**
+ * Currently non-functional. See:
+ * https://github.com/onmagnoliasquare/website/issues/166#issuecomment-2496564881
+ */
+
+// @vitest-environment jsdom
+// import ArticleBoxC from '$components/home/ArticleBoxC.svelte';
+// import { render, screen } from '@testing-library/svelte';
+// import { expect, test } from 'vitest';
+
+// test('ArticleBox can render all props', () => {
+// 	render(ArticleBoxC, {
+// 		article: {
+// 			_type: 'article',
+// 			_createdAt: '',
+// 			updatedDate: '',
+// 			title: 'Test Article',
+// 			subtitle: 'Some kinda something',
+// 			date: '2024-11-25',
+// 			slug: {
+// 				_type: 'slug',
+// 				current: 'test-article'
+// 			},
+// 			category: {
+// 				_type: 'category',
+// 				_createdAt: '',
+// 				name: '',
+// 				slug: {
+// 					_type: 'slug',
+// 					current: 'news'
+// 				},
+// 				description: '',
+// 				metaInfo: {}
+// 			},
+// 			tags: [],
+// 			authors: [
+// 				{
+// 					_type: 'member',
+// 					name: '',
+// 					slug: {
+// 						current: 'neo-alabastro',
+// 						_type: 'slug'
+// 					},
+// 					metaInfo: {}
+// 				}
+// 			],
+// 			metaInfo: {}
+// 		}
+// 	});
+
+// 	expect(screen.queryByText('Test Article')).toBeInTheDocument();
+// });

--- a/packages/frontend/src/components/article/ByLine.svelte
+++ b/packages/frontend/src/components/article/ByLine.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createAuthorString } from '$lib/helpers';
+	import { createAuthorLink, createAuthorString } from '$lib/helpers';
 	import type { Member } from '$lib/schema';
 
 	interface Props {
@@ -12,29 +12,29 @@
 
 <div>
 	{#if authors.length == 1}
-		<a href={`/about/staff/${authors[0].slug.current}`} class="pa0 ma0 di">
+		<a href={createAuthorLink('', authors[0].slug.current)} class="pa0 ma0 di">
 			<p class="pa0 ma0 lh-copy tracked-02 fw6 f6">{authors[0].name}</p>
 		</a>
 	{:else if authors.length == 2}
-		<a href={`/about/staff/${authors[0].slug.current}`} class="pa0 ma0 di">
+		<a href={createAuthorLink('', authors[0].slug.current)} class="pa0 ma0 di">
 			<p class="pa0 ma0 lh-copy tracked-02 fw6 f6">{authors[0].name}</p>
 		</a>
 		<p class="pa0 ma0 lh-copy tracked-02 fw6 f6">&</p>
-		<a href={`/about/staff/${authors[1].slug.current}`} class="pa0 ma0 di">
+		<a href={createAuthorLink('', authors[1].slug.current)} class="pa0 ma0 di">
 			<p class="pa0 ma0 lh-copy tracked-02 fw6 f6">{authors[1].name}</p>
 		</a>
 	{:else}
 		<ul class="list ma0 pa0 di">
 			{#each authors.slice(0, authors.length - 1) as author}
 				<li class="ma0 pa0">
-					<a href={`/about/staff/${author.slug.current}`} class="pa0 ma0">
+					<a href={createAuthorLink('', author.slug.current)} class="pa0 ma0">
 						<p class="di pa0 ma0 lh-copy tracked-02 fw6 f6">{author.name}</p>
 					</a>
 					<!-- https://github.com/sveltejs/svelte/issues/3080#issuecomment-2030815987 -->
 				</li>
 			{/each}
 			<li>
-				<a href={`/about/staff/${authors[authors.length - 1].slug.current}`} class="pa0 ma0 di">
+				<a href={createAuthorLink('', authors[authors.length - 1].slug.current)} class="pa0 ma0 di">
 					<p class="pa0 ma0 lh-copy tracked-02 fw6 f6">{authors[authors.length - 1].name}</p>
 				</a>
 			</li>

--- a/packages/frontend/src/components/general/VersionLabel.svelte
+++ b/packages/frontend/src/components/general/VersionLabel.svelte
@@ -5,7 +5,7 @@
 
 <div class="ph3">
 	<a href={`https://github.com/onmagnoliasquare/website/releases/tag/v${semVer}`} target="_blank">
-		<p class="f6 pa0 ma0 font-monospace tracked-tight gray">
+		<p class="f6 pa0 ma0 font-monospace tracked-tight">
 			v{semVer}
 		</p>
 	</a>

--- a/packages/frontend/src/components/home/HomepageHero.svelte
+++ b/packages/frontend/src/components/home/HomepageHero.svelte
@@ -15,7 +15,7 @@
 <a
 	data-sveltekit-preload-data="hover"
 	data-sveltekit-preload-code="eager"
-	href={`/category/${article.category.name}/${article.slug.current}`}
+	href={`/category/${article.category.name.toLowerCase()}/${article.slug.current}`}
 	class="no-underline"
 >
 	<article>

--- a/packages/frontend/src/hooks.server.ts
+++ b/packages/frontend/src/hooks.server.ts
@@ -164,7 +164,19 @@ const logSpeed: Handle = async ({ event, resolve }) => {
 	return response;
 };
 
-export const handle = sequence(redirectCaps, redirectTag, redirectHome, logSpeed);
+/**
+ * preflightOptions returns a 200-ok response for OPTIONS requests.
+ * This is a default hook that allows SvelteKit to function as a backend API.
+ * See: https://www.jefmeijvis.com/blog/006-sveltekit-api-endpoints
+ * @returns `Response`
+ */
+export const preflightOptions: Handle = async ({ event, resolve }) => {
+	if (event.request.method !== 'OPTIONS') return await resolve(event);
+
+	return new Response(new Blob(), { status: 200 });
+};
+
+export const handle = sequence(redirectCaps, redirectTag, redirectHome, preflightOptions, logSpeed);
 
 // MAYBE:
 // Maybe also add a HTTP rewriter?

--- a/packages/frontend/src/hooks.test.ts
+++ b/packages/frontend/src/hooks.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { preflightOptions } from './hooks.server';
+
+describe('preflightOptions', () => {
+	it('should return 200 OK for OPTIONS requests', async () => {
+		// Mock event object for OPTIONS request
+		const mockEvent = {
+			request: {
+				method: 'OPTIONS'
+			}
+		} as any; // Cast as any to mock event shape
+
+		const mockResolve = vi.fn(); // Mock the resolve function
+
+		// Call the function
+		const response = await preflightOptions({ event: mockEvent, resolve: mockResolve });
+
+		// Assertions
+		expect(response.status).toBe(200); // Ensure status is 200
+		expect(mockResolve).not.toHaveBeenCalled(); // Ensure resolve was not called
+	});
+
+	it('should call resolve for non-OPTIONS requests', async () => {
+		// Mock event object for a GET request
+		const mockEvent = {
+			request: {
+				method: 'GET'
+			}
+		} as any;
+
+		// Mock resolve function
+		const mockResolve = vi.fn().mockResolvedValue(new Response('Resolved'));
+
+		// Call the function
+		const response = await preflightOptions({ event: mockEvent, resolve: mockResolve });
+
+		// Assertions
+		expect(mockResolve).toHaveBeenCalled(); // Ensure resolve was called
+		expect(response).toBeInstanceOf(Response); // Ensure a Response is returned
+	});
+});

--- a/packages/frontend/src/lib/helpers.ts
+++ b/packages/frontend/src/lib/helpers.ts
@@ -84,6 +84,14 @@ export const createAuthorLink = (url: string, slug: string): string => {
 	return `${url}/about/staff/${slug}`;
 };
 
+/**
+ * createSiteTitle creates a formatted site title by appending
+ * a provided title to the site's name with an EN-DASH in between.
+ * If no title is provided, it returns the site's name.
+ * @param name - The name of the site
+ * @param title - An optional title to append
+ * @returns A formatted string representing the complete site title
+ */
 export const createSiteTitle = (name: string, title?: string): string => {
 	if (title) {
 		// The dash below is an EN-DASH (U+2013)

--- a/packages/frontend/src/lib/sanity.ts
+++ b/packages/frontend/src/lib/sanity.ts
@@ -97,7 +97,13 @@ export function unequal(leftSide: string, rightSide: string | boolean): string {
 
 /**
  * buildSanityQuery constructs a sanity query string which is passed
- * to `sanity` fetch functions.
+ * to `sanity` fetch functions. Keep in mind, there is a library for this:
+ * https://github.com/FormidableLabs/groqd/tree/main/packages/groq-builder.
+ * However, it would be unnecessary to include, because:
+ *
+ * - Our queries aren't too complex.
+ * - It would require learning a new library.
+ *
  * @param sq The sanity query to execute.
  * @returns a serialized query string.
  */

--- a/packages/frontend/src/lib/schema.d.ts
+++ b/packages/frontend/src/lib/schema.d.ts
@@ -18,9 +18,9 @@ export interface Member {
 	bio?: string;
 	portrait?: CustomImageAsset;
 	slug: Slug;
-	from: From;
+	from?: From;
 	committee?: Committee;
-	handles: Handles;
+	handles?: Handles;
 	metaInfo: MetaInfo;
 }
 
@@ -96,11 +96,11 @@ export interface Article {
 	abstract?: string;
 	date: string;
 	slug: Slug;
-	series: Series;
+	series?: Series;
 	category: Category;
 	tags: Tag[];
 	authors: Member[];
-	content: PortableTextBlock[];
+	content?: PortableTextBlock[];
 	// content: PortableTextComponents[];
 
 	// headerImage and media both refer to the topmost
@@ -112,7 +112,7 @@ export interface Article {
 	// takes the `media` attribute in the function
 	// signature, and the `altText` is retrieved from
 	// the headerImage attribute.
-	media: Image;
+	media?: Image;
 
 	/**
 	 * HeaderImage exists because ImageAsset, for some reason,
@@ -120,7 +120,7 @@ export interface Article {
 	 * the future, it receives one. For now, this must be
 	 * implemented.
 	 */
-	headerImage: CustomImageAsset;
+	headerImage?: CustomImageAsset;
 
 	metaInfo: MetaInfo;
 }

--- a/packages/frontend/src/routes/(app)/+layout.svelte
+++ b/packages/frontend/src/routes/(app)/+layout.svelte
@@ -28,6 +28,6 @@
 <!-- This is the main layout for the entire website. -->
 <Header />
 
-<main class="pb4 pb7-ns">
+<div class="pb4 pb7-ns">
 	{@render children()}
-</main>
+</div>

--- a/packages/frontend/src/routes/(app)/about/+page.server.ts
+++ b/packages/frontend/src/routes/(app)/about/+page.server.ts
@@ -1,7 +1,11 @@
+import { dev } from '$app/environment';
+
+export const csr = dev;
+
 import { site } from '$lib/variables';
 import type { MetaTagsProps } from 'svelte-meta-tags';
-import type { PageServerLoad } from './$types';
 import { createSiteTitle } from '$lib/helpers';
+import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = (async () => {
 	const title = 'About';

--- a/packages/frontend/src/routes/(app)/about/staff/+page.server.ts
+++ b/packages/frontend/src/routes/(app)/about/staff/+page.server.ts
@@ -45,6 +45,7 @@ export const load: PageServerLoad = (async () => {
 				description: ogDescription
 			}
 		}) satisfies MetaTagsProps;
+
 		return {
 			title,
 			members,

--- a/packages/frontend/src/routes/(app)/about/staff/+page.server.ts
+++ b/packages/frontend/src/routes/(app)/about/staff/+page.server.ts
@@ -1,6 +1,6 @@
 import { dev } from '$app/environment';
 
-export const csr = dev;
+export const csr = false;
 
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
@@ -31,7 +31,7 @@ export const load: PageServerLoad = (async () => {
 		const title = 'Staff';
 
 		const ogTitle = createSiteTitle(site.name, title);
-		const ogDescription = `Our staff and contributors at ${site.name}`;
+		const ogDescription = `Staff and contributors at ${site.name}.`;
 
 		const pageMetaTags = Object.freeze({
 			title: ogTitle,

--- a/packages/frontend/src/routes/(app)/about/staff/+page.server.ts
+++ b/packages/frontend/src/routes/(app)/about/staff/+page.server.ts
@@ -1,3 +1,7 @@
+import { dev } from '$app/environment';
+
+export const csr = dev;
+
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { buildSanityQuery, sanityFetch } from '$lib/sanity';

--- a/packages/frontend/src/routes/(app)/about/staff/+page.svelte
+++ b/packages/frontend/src/routes/(app)/about/staff/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import StaffGrid from '$components/about/StaffGrid.svelte';
-	import NormalCentering from '$components/NormalCentering.svelte';
 	import PageHeader from '$components/PageHeader.svelte';
 	import type { PageData } from './$types';
 

--- a/packages/frontend/src/routes/(app)/about/staff/[name]/+page.server.ts
+++ b/packages/frontend/src/routes/(app)/about/staff/[name]/+page.server.ts
@@ -1,3 +1,7 @@
+import { dev } from '$app/environment';
+
+export const csr = dev;
+
 import { error, type ServerLoadEvent } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { buildSanityQuery, equal, sanityFetch } from '$lib/sanity';

--- a/packages/frontend/src/routes/(app)/about/staff/[name]/+page.svelte
+++ b/packages/frontend/src/routes/(app)/about/staff/[name]/+page.svelte
@@ -84,7 +84,7 @@
 						<li>
 							<ContactIcons
 								icon="/icons/instagram.svg"
-								title={`@${handles.instagram}`}
+								title={`${handles.instagram}`}
 								link={`https://instagram.com/${handles.instagram}`}
 							/>
 						</li>

--- a/packages/frontend/src/routes/(app)/category/[category=categories]/+page.server.ts
+++ b/packages/frontend/src/routes/(app)/category/[category=categories]/+page.server.ts
@@ -6,26 +6,15 @@ import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = (async (event: ServerLoadEvent) => {
 	let sanityQuery: string;
-	let cat: Category | undefined;
 	let articles: Article[] | undefined;
 
 	// Retrieve the name of the category from the URL.
 	const { category } = event.params!;
 
 	// Get category information.
-	try {
-		sanityQuery = buildSanityQuery({
-			type: 'category',
-			conditions: [`slug.current == '${category as string}'`],
-			idx: [0],
-			attributes: ['name', 'description', 'slug', 'useCustomCss', 'metaInfo']
-		});
 
-		cat = await sanityFetch(sanityQuery);
-	} catch (err) {
-		console.error(err);
-		throw error(500, 'Server network error...');
-	}
+	const req = await event.fetch(`/api/category/${category}`);
+	const cat: Category | undefined = await req.json();
 
 	if (!cat) throw error(404, "That category doesn't exist...");
 

--- a/packages/frontend/src/routes/(app)/category/[category=categories]/+page.server.ts
+++ b/packages/frontend/src/routes/(app)/category/[category=categories]/+page.server.ts
@@ -1,8 +1,8 @@
 import { error, type ServerLoadEvent } from '@sveltejs/kit';
 import { buildSanityQuery, sanityFetch } from '$lib/sanity';
-import type { PageServerLoad } from './$types';
 import type { MetaTagsProps } from 'svelte-meta-tags';
 import type { Article, Category } from '$lib/schema';
+import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = (async (event: ServerLoadEvent) => {
 	let sanityQuery: string;

--- a/packages/frontend/src/routes/(app)/category/[category=categories]/+page.svelte
+++ b/packages/frontend/src/routes/(app)/category/[category=categories]/+page.svelte
@@ -36,7 +36,9 @@
 		{#each articles as article}
 			<!-- #key is a fix for https://github.com/onmagnoliasquare/website/issues/96  -->
 			{#key article}
-				<ArticleBoxC {article} />
+				<li>
+					<ArticleBoxC {article} />
+				</li>
 			{/key}
 		{/each}
 	</ul>

--- a/packages/frontend/src/routes/(app)/category/[category=categories]/[slug]/+page.server.ts
+++ b/packages/frontend/src/routes/(app)/category/[category=categories]/[slug]/+page.server.ts
@@ -98,5 +98,5 @@ export const load: PageServerLoad = (async (event: ServerLoadEvent) => {
 		};
 	}
 
-	throw error(req.status, 'Article not found...');
+	throw error(404, 'Article not found...');
 }) satisfies PageServerLoad;

--- a/packages/frontend/src/routes/(app)/category/[category=categories]/[slug]/+page.svelte
+++ b/packages/frontend/src/routes/(app)/category/[category=categories]/[slug]/+page.svelte
@@ -49,11 +49,11 @@
 						src={urlFor(data.article.media).format('webp').fit('max').url()}
 						alt={data.article.media.alt}
 					/>
-					{#if data.article.headerImage.creditLine}
+					{#if data.article.headerImage!.creditLine}
 						<figcaption class="fw5 f6 gray ph1">
 							<div class="mt1">
 								<p class="pa0 ma0 i o-40">
-									Photo credit: {data.article.headerImage.creditLine}
+									Photo credit: {data.article.headerImage!.creditLine}
 								</p>
 							</div>
 						</figcaption>

--- a/packages/frontend/src/routes/(app)/category/[category=categories]/[slug]/+page.svelte
+++ b/packages/frontend/src/routes/(app)/category/[category=categories]/[slug]/+page.svelte
@@ -121,15 +121,17 @@
 	{#if data.article.tags}
 		<div data-sveltekit-preload-data="false" class="mt5">
 			<a href="/archive" class="dib no-underline">
-				<h4 class="sans-serif fw7 ma0">Tags</h4>
+				<h3 class="sans-serif fw7 ma0">Tags</h3>
 			</a>
 			<!-- `<ul>` for accessibility -->
 			<ul class="list pa0 flex flex-wrap items-center justify-left">
 				{#each data.article.tags as tag}
 					<li class="pa0 ma0 pr1">
-						<a href={`/archive/tags/${tag.slug.current}`}>
-							<Tag tagName={tag.name} />
-						</a>
+						<div>
+							<a href={`/archive/tags/${tag.slug.current}`}>
+								<Tag tagName={tag.name} />
+							</a>
+						</div>
 					</li>
 				{/each}
 			</ul>

--- a/packages/frontend/src/routes/(app)/series/+page.server.ts
+++ b/packages/frontend/src/routes/(app)/series/+page.server.ts
@@ -1,3 +1,7 @@
+import { dev } from '$app/environment';
+
+export const csr = dev;
+
 import { error } from '@sveltejs/kit';
 import { buildSanityQuery, sanityFetch } from '$lib/sanity';
 import type { PageServerLoad } from './$types';

--- a/packages/frontend/src/routes/(app)/series/[series]/+page.server.ts
+++ b/packages/frontend/src/routes/(app)/series/[series]/+page.server.ts
@@ -45,6 +45,7 @@ export const load: PageServerLoad = (async (event: ServerLoadEvent) => {
 		const articles: Article[] = await sanityFetch(sanityQuery);
 
 		const title = seriesPage.name;
+		const description = seriesPage.description;
 
 		let ogTitle = createSiteTitle(site.title, title);
 
@@ -81,6 +82,7 @@ export const load: PageServerLoad = (async (event: ServerLoadEvent) => {
 		return {
 			articles,
 			title,
+			description,
 			pageMetaTags
 		};
 	}

--- a/packages/frontend/src/routes/(app)/series/[series]/+page.server.ts
+++ b/packages/frontend/src/routes/(app)/series/[series]/+page.server.ts
@@ -1,3 +1,7 @@
+import { dev } from '$app/environment';
+
+export const csr = dev;
+
 import { error, type ServerLoadEvent } from '@sveltejs/kit';
 import { buildSanityQuery, equal, sanityFetch } from '$lib/sanity';
 import type { PageServerLoad } from './$types';

--- a/packages/frontend/src/routes/(app)/series/[series]/+page.server.ts
+++ b/packages/frontend/src/routes/(app)/series/[series]/+page.server.ts
@@ -30,7 +30,7 @@ export const load: PageServerLoad = (async (event: ServerLoadEvent) => {
 		// The description is expected to end in a punctuation, like a period
 		// exclamation point, or a comma. Therefore, there is none in
 		// the string below.
-		let ogDescription = `${seriesPage.description} Read more at ${site.title}`;
+		let ogDescription = `${seriesPage.description} Read more at ${site.title}.`;
 		if (seriesPage.metaInfo) {
 			if (seriesPage.metaInfo.ogTitle) {
 				ogTitle = seriesPage.metaInfo.ogTitle;

--- a/packages/frontend/src/routes/(app)/series/[series]/+page.svelte
+++ b/packages/frontend/src/routes/(app)/series/[series]/+page.svelte
@@ -11,11 +11,13 @@
 
 	let { data }: Props = $props();
 	let articles: Article[] = data.articles;
+	let title: string = data.title;
+	let description: string = data.description;
 </script>
 
 <NormalCentering>
-	<PageHeader>{articles[0].series.name}</PageHeader>
-	<p class="tracked-02 pa1">{articles[0].series.description}</p>
+	<PageHeader>{title}</PageHeader>
+	<p class="tracked-02 pa1">{description}</p>
 	<ol class="list pa0 ma0">
 		{#each articles as article}
 			<li class="ma0 pa0">

--- a/packages/frontend/src/routes/(home)/+layout.svelte
+++ b/packages/frontend/src/routes/(home)/+layout.svelte
@@ -6,6 +6,4 @@
 <!-- Header is duplicated here for special customization -->
 <Header />
 
-<main>
-	{@render children()}
-</main>
+{@render children()}

--- a/packages/frontend/src/routes/(home)/+page.server.ts
+++ b/packages/frontend/src/routes/(home)/+page.server.ts
@@ -2,29 +2,13 @@
 
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import { buildSanityQuery, sanityFetch, unequal } from '$lib/sanity';
 import type { Article } from '$lib/schema';
 
 // https://kit.svelte.dev/docs/load#page-data
-export const load: PageServerLoad = (async () => {
-	let sanityQuery: string;
-	let articles: Article[] | undefined;
+export const load: PageServerLoad = (async ({ fetch }) => {
+	const req = await fetch(`/api/homepage`);
 
-	try {
-		sanityQuery = buildSanityQuery({
-			type: 'article',
-			conditions: [`${unequal('wasDeleted', true)}`, `${unequal('isDraft', true)}`],
-			attributes: ['title', 'subtitle', 'date', 'slug', 'media'],
-			customAttrs: ['category->{name}', 'authors[]->{name}'],
-			idx: [0, 10],
-			order: 'date desc'
-		});
-
-		articles = await sanityFetch(sanityQuery);
-	} catch (err) {
-		console.error(err);
-		throw error(500, 'Server network error...');
-	}
+	const articles: Article[] | undefined = await req.json();
 
 	if (articles) {
 		return {

--- a/packages/frontend/src/routes/+layout.svelte
+++ b/packages/frontend/src/routes/+layout.svelte
@@ -27,26 +27,31 @@
 
 <MetaTags {...metaTags} />
 
-{#if isDevEnv}
-	<div class="w-100 ma0 pa0 bg-red">
+<header>
+	{#if isDevEnv}
+		<div class="w-100 ma0 pa0 bg-red">
+			<div class="mw9 center ma0 pa0">
+				<div class="flex flex-flow items-center justify-center">
+					<p class="ttu sans-serif fw4 tracked-02 f5 fw8 pa0 ma0 white">
+						⚠️ This is a development Environment - Do not touch production dataset ️⚠️
+					</p>
+				</div>
+			</div>
+		</div>
+	{/if}
+	<div class="w-100 ma0 pa1">
 		<div class="mw9 center ma0 pa0">
-			<div class="flex flex-flow items-center justify-center">
-				<p class="ttu sans-serif fw4 tracked-02 f5 fw8 pa0 ma0 white">
-					⚠️ This is a development Environment - Do not touch production dataset ️⚠️
-				</p>
+			<div class="flex flex-row-reverse items-center justify-left">
+				<VersionLabel />
 			</div>
 		</div>
 	</div>
-{/if}
-<div class="w-100 ma0 pa1">
-	<div class="mw9 center ma0 pa0">
-		<div class="flex flex-row-reverse items-center justify-left">
-			<VersionLabel />
-		</div>
+</header>
+
+<main>
+	<div class="mw9 w-100 center pa1 pa3-l">
+		{@render children()}
 	</div>
-</div>
-<div class="mw9 w-100 center pa1 pa3-l">
-	{@render children()}
-</div>
+</main>
 
 <Footer />

--- a/packages/frontend/src/routes/+layout.ts
+++ b/packages/frontend/src/routes/+layout.ts
@@ -14,13 +14,16 @@ export const load: LayoutLoad = async ({ url, data }) => {
 			? data.acceptedLanguage
 			: site.locale;
 
+	const newUrl = new URL(url.pathname, site.url).href;
+
 	const baseMetaTags = Object.freeze({
 		title: createSiteTitle(site.title),
 		description: site.description,
-		canonical: new URL(url.pathname, url.origin).href,
+		canonical: newUrl,
 		openGraph: {
 			type: 'website',
-			url: new URL(url.pathname, url.origin).href,
+			// url: new URL(url.pathname, url.origin).href,
+			url: newUrl,
 			locale: site.locale,
 			title: site.title,
 			description: site.description,

--- a/packages/frontend/src/routes/api/article/+server.ts
+++ b/packages/frontend/src/routes/api/article/+server.ts
@@ -22,8 +22,8 @@ export const GET: RequestHandler = async ({ url }) => {
 			type: 'article',
 			idx: [0],
 			conditions: [
-				`${equal('category->slug.current', (category as string).toLowerCase())}`,
-				`${equal('slug.current', slug as string)}`
+				equal('category->slug.current', (category as string).toLowerCase()),
+				equal('slug.current', slug as string)
 			],
 			attributes: ['title', 'subtitle', 'date', 'media', 'updatedDate', 'metaInfo'],
 			customAttrs: [

--- a/packages/frontend/src/routes/api/article/+server.ts
+++ b/packages/frontend/src/routes/api/article/+server.ts
@@ -1,0 +1,59 @@
+import { buildSanityQuery, equal, sanityFetch } from '$lib/sanity';
+import type { Article } from '$lib/schema';
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async ({ url }) => {
+	let sanityQuery: string;
+
+	const category = url.searchParams.get('category');
+	const slug = url.searchParams.get('slug');
+
+	if (!category || !slug) {
+		return json(
+			{ error: 'Missing category or slug parameter' },
+			{ status: 400 } // Bad Request
+		);
+	}
+
+	let article: Article | undefined;
+
+	try {
+		sanityQuery = buildSanityQuery({
+			type: 'article',
+			idx: [0],
+			conditions: [
+				`${equal('category->slug.current', (category as string).toLowerCase())}`,
+				`${equal('slug.current', slug as string)}`
+			],
+			attributes: ['title', 'subtitle', 'date', 'media', 'updatedDate', 'metaInfo'],
+			customAttrs: [
+				`content[]{
+					_type == "image" => {
+						title,
+						alt,
+						description,
+						"attrs": asset-> {
+							metadata,
+							creditLine,
+						}
+					},
+					...
+				}`,
+				'authors[]->{name, slug}',
+				'tags[]->{name, slug}',
+				'category->{name, slug}',
+				`"headerImage": media.asset->{creditLine}`
+			]
+		});
+
+		article = await sanityFetch(sanityQuery);
+	} catch (err) {
+		console.error(err);
+		return json(
+			{ message: 'Failed to fetch article', error: (err as Error).message },
+			{ status: 500 }
+		);
+	}
+
+	return json(article);
+};

--- a/packages/frontend/src/routes/api/category/[category=categories]/+server.ts
+++ b/packages/frontend/src/routes/api/category/[category=categories]/+server.ts
@@ -1,0 +1,32 @@
+import { buildSanityQuery, equal, sanityFetch } from '$lib/sanity';
+import type { Article, Category } from '$lib/schema';
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async ({ params }) => {
+	let sanityQuery: string;
+	const category = params;
+	let cat: Category | undefined;
+
+	if (!category) {
+		return json({ error: 'Missing category' }, { status: 400 });
+	}
+
+	try {
+		sanityQuery = buildSanityQuery({
+			type: 'category',
+			conditions: [equal('slug.current', category.category as string)],
+			idx: [0],
+			attributes: ['name', 'description', 'slug', 'useCustomCss', 'metaInfo']
+		});
+
+		cat = await sanityFetch(sanityQuery);
+	} catch (err) {
+		console.error(err);
+		return json(
+			{ message: 'Failed to fetch category', error: (err as Error).message },
+			{ status: 500 }
+		);
+	}
+
+	return json(cat);
+};

--- a/packages/frontend/src/routes/api/homepage/+server.ts
+++ b/packages/frontend/src/routes/api/homepage/+server.ts
@@ -1,0 +1,47 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { buildSanityQuery, sanityFetch, unequal } from '$lib/sanity';
+import type { Article } from '$lib/schema';
+
+export const GET: RequestHandler = async ({}) => {
+	let sanityQuery: string;
+	let articles: Article[] | undefined;
+
+	try {
+		sanityQuery = buildSanityQuery({
+			type: 'article',
+			conditions: [unequal('wasDeleted', true), unequal('isDraft', true)],
+			attributes: ['title', 'subtitle', 'date', 'slug', 'media'],
+			customAttrs: ['category->{name}', 'authors[]->{name}'],
+			idx: [0, 10],
+			order: 'date desc'
+		});
+
+		articles = await sanityFetch(sanityQuery);
+
+		if (!articles || articles.length === 0) {
+			return json({ message: 'No articles found' }, { status: 404 });
+		}
+	} catch (err) {
+		console.error(err);
+		return json(
+			{ message: 'Failed to fetch articles', error: (err as Error).message },
+			{ status: 500 }
+		);
+	}
+	// console.log(JSON.stringify(articles, null, 2));
+
+	// console.log(JSON.stringify(articles));
+	// return JSON.stringify(articles);
+
+	// console.log(await json(articles).json());
+
+	return json(articles, {
+		headers: {
+			'Content-Type': 'application/json',
+			'Access-Control-Allow-Origin': '*', // Allow all origins
+			'Access-Control-Allow-Methods': 'GET, OPTIONS',
+			'Access-Control-Allow-Headers': 'Content-Type'
+		}
+	});
+};

--- a/packages/frontend/src/routes/api/member/[slug]/+server.ts
+++ b/packages/frontend/src/routes/api/member/[slug]/+server.ts
@@ -1,0 +1,50 @@
+import { buildSanityQuery, equal, sanityFetch } from '$lib/sanity';
+import type { Article, Member } from '$lib/schema';
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async ({ url, params }) => {
+	let sanityQuery: string;
+	let memberPage: Member | Article[] | undefined;
+
+	const { slug } = params;
+
+	if (!slug) {
+		return json({ error: 'Missing member slug' }, { status: 400 });
+	}
+
+	const getArticles = url.searchParams.get('articles');
+
+	if (getArticles && getArticles === 'true') {
+		sanityQuery = buildSanityQuery({
+			type: 'article',
+			conditions: [
+				`references(*[${equal('_type', 'member')}`,
+				`${equal('slug.current', slug)}]._id)`
+			],
+			attributes: ['title', 'subtitle', 'date', 'slug', 'media'],
+			customAttrs: ['authors[]->{name}', 'category->'],
+			order: 'date desc'
+		});
+	} else {
+		// Get member information.
+		sanityQuery = buildSanityQuery({
+			type: 'member',
+			conditions: [equal('slug.current', slug)],
+			idx: [0],
+			attributes: ['name', 'year', 'bio', 'handles', 'portrait', 'from'],
+			customAttrs: ['committee->{name}']
+		});
+	}
+
+	try {
+		memberPage = await sanityFetch(sanityQuery);
+	} catch (err) {
+		console.error(err);
+		return json(
+			{ message: 'Failed to fetch series', error: (err as Error).message },
+			{ status: 500 }
+		);
+	}
+
+	return json(memberPage);
+};

--- a/packages/frontend/src/routes/api/series/[slug]/+server.ts
+++ b/packages/frontend/src/routes/api/series/[slug]/+server.ts
@@ -1,0 +1,47 @@
+import { buildSanityQuery, equal, sanityFetch } from '$lib/sanity';
+import type { Article, Series } from '$lib/schema';
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async ({ url, params }) => {
+	let sanityQuery: string;
+
+	let seriesPage: Series | Article[] | undefined;
+
+	const { slug } = params;
+
+	if (!slug) {
+		return json({ error: 'Missing series slug' }, { status: 400 });
+	}
+
+	const getArticles = url.searchParams.get('articles');
+
+	if (getArticles && getArticles === 'true') {
+		sanityQuery = buildSanityQuery({
+			type: 'article',
+			conditions: [equal('series->slug.current', slug)],
+			attributes: ['title', 'subtitle', 'date', 'slug', 'media'],
+			customAttrs: ['authors[]->{name}', 'category->{name}', 'series->'],
+			order: 'date desc'
+		});
+	} else {
+		// Get series information.
+		sanityQuery = buildSanityQuery({
+			type: 'series',
+			idx: [0],
+			conditions: [equal('slug.current', slug)],
+			attributes: ['name', 'description', 'metaInfo']
+		});
+	}
+
+	try {
+		seriesPage = await sanityFetch(sanityQuery);
+	} catch (err) {
+		console.error(err);
+		return json(
+			{ message: 'Failed to fetch series', error: (err as Error).message },
+			{ status: 500 }
+		);
+	}
+
+	return json(seriesPage);
+};

--- a/packages/frontend/src/routes/api/tag/[slug]/+server.ts
+++ b/packages/frontend/src/routes/api/tag/[slug]/+server.ts
@@ -1,0 +1,49 @@
+import { buildSanityQuery, equal, sanityFetch } from '$lib/sanity';
+import type { Article, Tag } from '$lib/schema';
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async ({ url, params }) => {
+	let sanityQuery: string;
+
+	let tagPage: Tag | undefined;
+
+	const { slug } = params;
+
+	if (!slug) {
+		return json({ error: 'Missing tag slug' }, { status: 400 });
+	}
+
+	const getArticles = url.searchParams.get('articles');
+
+	if (getArticles && getArticles === 'true') {
+		sanityQuery = buildSanityQuery({
+			type: 'article',
+			conditions: [
+				`references((*[${equal('_type', 'tag')}`,
+				`${equal('slug.current', slug)}]._id))`
+			],
+			attributes: ['title', 'subtitle', 'date', 'slug', 'media'],
+			customAttrs: ['authors[]->{name}', 'category->']
+		});
+	} else {
+		// Get series information.
+		sanityQuery = buildSanityQuery({
+			type: 'tag',
+			conditions: [equal('slug.current', slug as string)],
+			idx: [0],
+			attributes: ['name', 'slug', 'description', 'metaInfo']
+		});
+	}
+
+	try {
+		tagPage = await sanityFetch(sanityQuery);
+	} catch (err) {
+		console.error(err);
+		return json(
+			{ message: 'Failed to fetch series', error: (err as Error).message },
+			{ status: 500 }
+		);
+	}
+
+	return json(tagPage);
+};

--- a/packages/frontend/tests/accessibility.test.ts
+++ b/packages/frontend/tests/accessibility.test.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright'; // 1
+
+/**
+ * We'll disable color contrast for now. This will be fixed
+ * when we re-audit UI/UX. These are disabled by the
+ * `disableRules` method on each `AxeBuilder` instantiation.
+ * See: https://playwright.dev/docs/accessibility-testing#disabling-individual-scan-rules
+ *
+ * CURRENTLY DISABLED CHECKS ID:
+ *   - 'color-contrast'
+ */
+
+const articleUrl = `/category/news/this-year's-changes-in-cost-of-attendance-and-financial-aid`;
+
+test('Homepage has no accessibility issues', async ({ page }) => {
+	await page.goto('/');
+
+	const accessibilityScanResults = await new AxeBuilder({ page })
+		.disableRules(['color-contrast'])
+		.analyze();
+
+	expect(accessibilityScanResults.violations).toHaveLength(0);
+});
+
+test('About page has no accessibility issues', async ({ page }) => {
+	await page.goto('/about');
+
+	const accessibilityScanResults = await new AxeBuilder({ page })
+		.disableRules(['color-contrast'])
+		.analyze();
+
+	expect(accessibilityScanResults.violations).toHaveLength(0);
+});
+
+test('Staff page has no accessibility issues', async ({ page }) => {
+	await page.goto('/about');
+
+	const accessibilityScanResults = await new AxeBuilder({ page })
+		.disableRules(['color-contrast'])
+		.analyze();
+
+	expect(accessibilityScanResults.violations).toHaveLength(0);
+});
+
+test('News page has no accessibility issues', async ({ page }) => {
+	await page.goto('/category/news');
+
+	const accessibilityScanResults = await new AxeBuilder({ page })
+		.disableRules(['color-contrast'])
+		.analyze();
+
+	expect(accessibilityScanResults.violations).toHaveLength(0);
+});
+
+test('Opinion page has no accessibility issues', async ({ page }) => {
+	await page.goto('/category/opinion');
+
+	const accessibilityScanResults = await new AxeBuilder({ page })
+		.disableRules(['color-contrast'])
+		.analyze();
+
+	expect(accessibilityScanResults.violations).toHaveLength(0);
+});
+
+test('People page has no accessibility issues', async ({ page }) => {
+	await page.goto('/category/people');
+
+	const accessibilityScanResults = await new AxeBuilder({ page })
+		.disableRules(['color-contrast'])
+		.analyze();
+
+	expect(accessibilityScanResults.violations).toHaveLength(0);
+});
+
+test('Culture page has no accessibility issues', async ({ page }) => {
+	await page.goto('/category/culture');
+
+	const accessibilityScanResults = await new AxeBuilder({ page })
+		.disableRules(['color-contrast'])
+		.analyze();
+
+	expect(accessibilityScanResults.violations).toHaveLength(0);
+});
+
+test('Multimedia page has no accessibility issues', async ({ page }) => {
+	await page.goto('/category/multimedia');
+
+	const accessibilityScanResults = await new AxeBuilder({ page })
+		.disableRules(['color-contrast'])
+		.analyze();
+
+	expect(accessibilityScanResults.violations).toHaveLength(0);
+});
+
+test('Series page has no accessibility issues', async ({ page }) => {
+	await page.goto('/series');
+
+	const accessibilityScanResults = await new AxeBuilder({ page })
+		.disableRules(['color-contrast'])
+		.analyze();
+
+	expect(accessibilityScanResults.violations).toHaveLength(0);
+});
+
+test('Archive page has no accessibility issues', async ({ page }) => {
+	await page.goto('/archive');
+
+	const accessibilityScanResults = await new AxeBuilder({ page })
+		.disableRules(['color-contrast'])
+		.analyze();
+
+	expect(accessibilityScanResults.violations).toHaveLength(0);
+});
+
+test('Article page has no accessibility issues', async ({ page }) => {
+	await page.goto(articleUrl);
+
+	const accessibilityScanResults = await new AxeBuilder({ page })
+		.disableRules(['color-contrast'])
+		.analyze();
+
+	expect(accessibilityScanResults.violations).toHaveLength(0);
+});

--- a/packages/frontend/tests/article.test.ts
+++ b/packages/frontend/tests/article.test.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test';
+
+const articleUrl = `/category/news/this-year's-changes-in-cost-of-attendance-and-financial-aid`;
+
+test('Article page has title', async ({ page }) => {
+	await page.goto(articleUrl);
+	await expect(
+		page.getByRole('heading', {
+			name: "This Year's Changes in Cost of Attendance and Financial Aid"
+		})
+	).toBeVisible();
+});
+
+test('Article page has authors and dates', async ({ page }) => {
+	await page.goto(articleUrl);
+
+	await expect(page.getByRole('link', { name: 'Fikret Halilov', exact: true })).toBeVisible();
+	await expect(page.getByRole('link', { name: 'Neo Alabastro', exact: true })).toBeVisible();
+
+	// Published At
+	await expect(page.getByRole('time').getByText('Sat, February 1, 2014 UTC')).toBeVisible();
+
+	// Updated At
+	await expect(page.getByRole('time').getByText('Mon, November 25, 2024 UTC')).toBeVisible();
+});
+
+test('Article page has tags', async ({ page }) => {
+	await page.goto(articleUrl);
+	await expect(
+		page.getByRole('heading', {
+			name: 'Tags'
+		})
+	).toBeVisible();
+});
+
+test('Article page loads SEO correctly', async ({ page }) => {
+	const description = 'School year price hikes are ever increasing, ever lasting...';
+	const title = "This Year's Changes in Cost of Attendance and Financial Aid: 2014-2024";
+
+	await page.goto(articleUrl);
+
+	await expect(page.locator('head meta[name="description"]')).toHaveAttribute(
+		'content',
+		description
+	);
+
+	await expect(page.locator('head meta[property="og:type"]')).toHaveAttribute('content', 'article');
+
+	await expect(page.locator('head meta[property="article:section"]')).toHaveAttribute(
+		'content',
+		'News'
+	);
+
+	const articleAuthor = page.locator('head meta[property="article:author"]');
+	await expect(articleAuthor).toHaveCount(2);
+	await expect(articleAuthor.nth(0)).toHaveAttribute(
+		'content',
+		'https://onmagnoliasquare.com/about/staff/fikret-halilov'
+	);
+	await expect(articleAuthor.nth(1)).toHaveAttribute(
+		'content',
+		'https://onmagnoliasquare.com/about/staff/neo-alabastro'
+	);
+
+	await expect(page.locator('head meta[property="og:url"]')).toHaveAttribute(
+		'content',
+		"https://onmagnoliasquare.com/category/news/this-year's-changes-in-cost-of-attendance-and-financial-aid"
+	);
+
+	/**
+	 * Article tags should load the defaults as defined in
+	 * `variables.ts`.
+	 */
+	const articleTags = page.locator('head meta[property="article:tag"]');
+	await expect(articleTags).toHaveCount(8);
+	await expect(articleTags.nth(0)).toHaveAttribute('content', 'student journalism');
+	await expect(articleTags.nth(1)).toHaveAttribute('content', 'nyu shanghai');
+	await expect(articleTags.nth(2)).toHaveAttribute('content', 'nyu');
+	await expect(articleTags.nth(3)).toHaveAttribute('content', 'oms');
+	await expect(articleTags.nth(4)).toHaveAttribute('content', 'on century avenue');
+	await expect(articleTags.nth(5)).toHaveAttribute('content', 'student life');
+	await expect(articleTags.nth(6)).toHaveAttribute('content', 'unbelievable news');
+	await expect(articleTags.nth(7)).toHaveAttribute('content', 'disappointment');
+
+	await expect(page.locator('head meta[property="article:published_time"]')).toHaveAttribute(
+		'content',
+		'2014-02-01T00:00:00Z'
+	);
+	await expect(page.locator('head meta[property="article:modified_time"]')).toHaveAttribute(
+		'content',
+		'2024-11-25T00:00:00Z'
+	);
+
+	await expect(page.locator('head meta[property="og:title"]')).toHaveAttribute('content', title);
+
+	await expect(page.locator('head meta[property="og:description"]')).toHaveAttribute(
+		'content',
+		description
+	);
+
+	await expect(page.locator('head meta[property="og:site_name"]')).toHaveAttribute(
+		'content',
+		'On Magnolia Square'
+	);
+
+	await expect(page.locator('head meta[property="og:locale"]')).toHaveAttribute('content', 'en-US');
+
+	// Twitter metadata.
+
+	await expect(page.locator('head meta[name="twitter:title"]')).toHaveAttribute('content', title);
+
+	await expect(page.locator('head meta[name="twitter:description"]')).toHaveAttribute(
+		'content',
+		description
+	);
+});

--- a/packages/frontend/tests/author.test.ts
+++ b/packages/frontend/tests/author.test.ts
@@ -15,6 +15,27 @@ test('Neo Alabastro page has IN COMMITTEE', async ({ page }) => {
 	await expect(page.getByRole('heading', { name: 'IN COMMITTEE', exact: true })).toBeVisible();
 });
 
+test('Neo Alabastro page has FROM', async ({ page }) => {
+	await page.goto('/about/staff/neo-alabastro');
+	await expect(page.getByRole('heading', { name: 'FROM', exact: true })).toBeVisible();
+});
+
+test('Neo Alabastro page has CONTACT', async ({ page }) => {
+	await page.goto('/about/staff/neo-alabastro');
+	await expect(page.getByRole('heading', { name: 'CONTACT', exact: true })).toBeVisible();
+});
+
+test('Neo Alabastro page has visible handles', async ({ page }) => {
+	await page.goto('/about/staff/neo-alabastro');
+
+	await expect(page.getByRole('link', { name: 'Neo Alabastro' })).toBeVisible();
+	await expect(page.getByRole('link', { name: 'neo.flac' })).toBeVisible();
+	await expect(page.getByRole('link', { name: 'idonthavetwitter' })).toBeVisible();
+	await expect(page.getByRole('link', { name: 'idontusefacebook' })).toBeVisible();
+	await expect(page.getByRole('link', { name: 'n30w' })).toBeVisible();
+	await expect(page.getByRole('link', { name: 'neoalabastro.com' })).toBeVisible();
+});
+
 test('Author accessible via article page', async ({ page }) => {
 	await page.goto(`/category/news/this-year's-changes-in-cost-of-attendance-and-financial-aid`);
 	await expect(
@@ -29,4 +50,49 @@ test('Author accessible via article page', async ({ page }) => {
 	await expect(
 		page.getByRole('main').getByRole('heading', { name: 'Fikret Halilov' })
 	).toBeVisible();
+});
+
+test('Member page loads SEO correctly', async ({ page }) => {
+	await page.goto(`/about/staff/neo-alabastro`);
+
+	await expect(page.locator('head meta[name="description"]')).toHaveAttribute(
+		'content',
+		'I am a web development team member.'
+	);
+
+	await expect(page.locator('head meta[property="og:type"]')).toHaveAttribute('content', 'profile');
+
+	await expect(page.locator('head meta[property="og:url"]')).toHaveAttribute(
+		'content',
+		'https://onmagnoliasquare.com/about/staff/neo-alabastro'
+	);
+
+	await expect(page.locator('head meta[property="og:title"]')).toHaveAttribute(
+		'content',
+		'About Neo Alabastro – On Magnolia Square'
+	);
+
+	await expect(page.locator('head meta[property="og:description"]')).toHaveAttribute(
+		'content',
+		'I am a web development team member.'
+	);
+
+	await expect(page.locator('head meta[property="og:site_name"]')).toHaveAttribute(
+		'content',
+		'On Magnolia Square'
+	);
+
+	await expect(page.locator('head meta[property="og:locale"]')).toHaveAttribute('content', 'en-US');
+
+	// Twitter metadata.
+
+	await expect(page.locator('head meta[name="twitter:title"]')).toHaveAttribute(
+		'content',
+		'About Neo Alabastro – On Magnolia Square'
+	);
+
+	await expect(page.locator('head meta[name="twitter:description"]')).toHaveAttribute(
+		'content',
+		'I am a web development team member.'
+	);
 });

--- a/packages/frontend/tests/test.ts
+++ b/packages/frontend/tests/test.ts
@@ -61,7 +61,8 @@ test('Category on by line accessible via article page', async ({ page }) => {
 	).toBeVisible();
 
 	// Click Category link on the ByLine.
-	await page.getByRole('main').getByRole('link', { name: 'News' }).click();
+	await page.getByRole('article').getByRole('link', { name: 'News' }).click();
+	// await page.getByRole('main').getByRole('link', { name: 'News' }).click();
 
 	await expect(page.getByRole('main').getByRole('heading', { name: 'News' })).toBeVisible();
 });

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
 	//@ts-ignore ts(2769)
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}'],
-		environment: 'jsdom',
-		setupFiles: ['./vitest-setup.js']
+		environment: 'node',
+		setupFiles: ['./vitest-setup.js'],
+		restoreMocks: true
 	}
 });


### PR DESCRIPTION
### Description

- Created api routes under `src/routes/api` for frontend. This abstracts the API layer from the rendering layer, and is better for unit and integration testing. DRY!
- Added playwright tests for integration and accessibility.
- Disable CSR in production mode for certain pages, like the about page.
- Comment housekeeping.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
