### PR TITLE
feat(b): add blurhash option

### DIFF
--- a/packages/backend/schemaTypes/article.tsx
+++ b/packages/backend/schemaTypes/article.tsx
@@ -1,12 +1,10 @@
-import {DocumentsIcon, ImageIcon, TagsIcon} from '@sanity/icons'
+import {DocumentsIcon, TagsIcon} from '@sanity/icons'
 import {defineArrayMember, defineField, defineType} from 'sanity'
 import slugValidator from '../lib/slugValidator'
 import abbreviateName from '../lib/abbreviateName'
 import {ContentGroup, InfoGroup, SeoGroup} from './objects/fieldGroups'
 import requiredFormattedString from './primitives/requiredFormattedString'
 import formattedText from './primitives/formattedText'
-import formattedString from './primitives/formattedString'
-import embeddedLink from './objects/embeddedLink'
 import metadataInformation from './objects/metadataInformation'
 import blockContent from './objects/blockContent'
 

--- a/packages/backend/schemaTypes/objects/blockContent.tsx
+++ b/packages/backend/schemaTypes/objects/blockContent.tsx
@@ -101,6 +101,7 @@ export default defineType({
           type: requiredFormattedString.name,
         },
       ],
+      options: ['blurhash'],
     },
     {
       type: embeddedLink.name,

--- a/packages/frontend/src/lib/sanity.ts
+++ b/packages/frontend/src/lib/sanity.ts
@@ -28,7 +28,7 @@ if (dev || import.meta.env.MODE === 'development') {
 	config.useCdn = false;
 } else if (import.meta.env.MODE === 'staging') {
 	config.dataset = 'staging';
-	config.useCdn = true;
+	config.useCdn = false;
 }
 
 export const client = createClient(config);


### PR DESCRIPTION
### Description

- Added blurhash option to Sanity backend.
- `useCdn` to false for frontend staging environment build.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
