### PR TITLE
feat: add `flake.nix` and `.envrc`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ packages/frontend/.wrangler
 .env
 .env.local
 
+.direnv
+
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ packages/frontend/.wrangler
 
 .direnv
 
+mprocs.log
+
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,37 @@
 
 On Magnolia Square website monorepo for frontend and backend.
 
-## Prerequisites
+## Getting Started
 
-Please first have **yarn** installed on your computer first before starting
-development. Here is the
-[yarn documentation for installing it](https://yarnpkg.com/corepack#installation).
+There are two ways to setup a development environment to get started.
 
-### MacOS - `brew` specific
+### Using Nix
+
+It is highly recommended to use the Nix flake in this repository to setup the development environment._For your convenience, there is also a `.envrc` file ready to go (but you might've noticed that already)._
+
+Using a Nix flake requires the [`nix` package manager](https://nixos.org/download/) and experimental flakes in the nix configuration **enabled**. (If you use MacOS, the [nix determinate installer](https://zero-to-nix.com/concepts/nix-installer/) is effective)
+
+Run this command in the repository.
+
+```bash
+nix develop
+```
+
+This will install all required development tools, like yarn, as well as `node_modules` for web dependencies.
+
+If you don't have `direnv` install, you need to rerun the `nix develop` command every time you re-enter this repository.
+
+### Manual Steps
+
+Prerequisite dependencies:
+
+- Node version >= 22.x.x
+- Yarn version >= 4.7.x
+
+`yarn` is our package manager of choice. Here is the
+[yarn documentation for installing it on your system](https://yarnpkg.com/corepack#installation).
+
+#### MacOS with `brew`
 
 If you're using MacOS the brew package `corepack` is needed. Corepack ships with
 Node, but zsh does not find this linkage in the shell. Therefore, since we are
@@ -27,9 +51,11 @@ Now, run `corepack enable`. This will enable corepack globally. Optionally, one
 can run `corepack install --global yarn@stable` to install the latest yarn
 version globally using corepack.
 
-### Windows
+#### Windows
 
-Install `node` on Windows and enable corepack. Make sure to run powershell in administrator mode. An error may occur when using yarn, something along the lines of `yarn.ps1 cannot be loaded`.
+Install `node` on Windows and enable corepack. Make sure to run powershell in administrator mode.
+
+An error may occur when using yarn, something along the lines of `yarn.ps1 cannot be loaded`.
 
 To fix this, input this command into the current powershell terminal session:
 
@@ -37,7 +63,11 @@ To fix this, input this command into the current powershell terminal session:
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ```
 
-## Setup
+#### Linux
+
+If you're using Linux, make sure you have the prerequisite dependencies installed.
+
+### Setup
 
 In the repository's root directory, run the following commands:
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738958807,
+        "narHash": "sha256-h0WKgHTLkjwjRNTkqByQquS7N/15SqIFMQ356Ww8uCA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e8d0b02af0958823c955aaab3c82b03f54411d91",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738958807,
-        "narHash": "sha256-h0WKgHTLkjwjRNTkqByQquS7N/15SqIFMQ356Ww8uCA=",
+        "lastModified": 1742800061,
+        "narHash": "sha256-oDJGK1UMArK52vcW9S5S2apeec4rbfNELgc50LqiPNs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8d0b02af0958823c955aaab3c82b03f54411d91",
+        "rev": "1750f3c1c89488e2ffdd47cab9d05454dddfb734",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -24,22 +24,28 @@
         commonPackages = with pkgs; [
           # Development related
           nodejs_22
+          yarn-berry
           typescript
           typescript-language-server
 
-          # System tools
           lazygit
+          imagemagick
+          jq
+
+          # System tools
           htop
           mprocs
         ];
-
       in
       {
         devShell = pkgs.mkShell {
           buildInputs = [ commonPackages ];
           shellHook = ''
-               # Customize the prompt to show we're in a Nix environment
+            # Customize the prompt to show we're in a Nix environment
             export PS1='$(printf "\033[01;34m(nix) \033[00m\033[01;32m[%s] \033[01;33m(node $(node -v))\033[00m$\033[00m " "\W")'
+
+            # Initialize yarn
+            yarn
           '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+# modified from https://github.com/akirak/flake-templates/blob/master/node-typescript/flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config = {
+            allowUnfree = true;
+          };
+        };
+
+        commonPackages = with pkgs; [
+          # Development related
+          nodejs_22
+          typescript
+          typescript-language-server
+
+          # System tools
+          lazygit
+          htop
+          mprocs
+        ];
+
+      in
+      {
+        devShell = pkgs.mkShell {
+          buildInputs = [ commonPackages ];
+          shellHook = ''
+               # Customize the prompt to show we're in a Nix environment
+            export PS1='$(printf "\033[01;34m(nix) \033[00m\033[01;32m[%s] \033[01;33m(node $(node -v))\033[00m$\033[00m " "\W")'
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
### Description

Added a `nix` flake development environment capability. May add actions caching in the future for dependencies.

Safari Webkit tests do not seem to pass deterministically in integration tests. Will remove if this creates CI issues.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
