### PR TITLE
ci: add studio title var for backend deploy

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -52,10 +52,9 @@ jobs:
     runs-on: ubuntu-${{ vars.RUNNER_VERSION }}
     environment: production
     env:
-      SANITY_PROJECT_ID: ${{ vars.SANITY_PROJECT_ID }}
       SANITY_API_VERSION: ${{ vars.SANITY_API_VERSION }}
       SANITY_DATASET: ${{ vars.SANITY_STUDIO_DATASET }}
-      SANITY_DEVELOPER_TOKEN: ${{ secrets.SANITY_DEVELOPER_TOKEN }}
+      SANITY_STUDIO_TITLE: ${{ vars.SANITY_STUDIO_TITLE }}
       YARN_VERSION: ${{ needs.build.outputs.yarn_version }}
     permissions:
       contents: read

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -13,6 +13,10 @@ jobs:
     environment: production
     outputs:
       yarn_version: ${{ steps.set_yarn_version.outputs.yarn_version }}
+    env:
+      SANITY_API_VERSION: ${{ vars.SANITY_API_VERSION }}
+      SANITY_DATASET: ${{ vars.SANITY_STUDIO_DATASET }}
+      SANITY_STUDIO_TITLE: ${{ vars.SANITY_STUDIO_TITLE }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -65,6 +65,9 @@ jobs:
     needs: build
     env:
       YARN_VERSION: ${{ needs.build.outputs.yarn_version }}
+      SANITY_API_VERSION: ${{ vars.SANITY_API_VERSION }}
+      SANITY_DATASET: ${{ vars.SANITY_STUDIO_DATASET }}
+      SANITY_STUDIO_TITLE: ${{ vars.SANITY_STUDIO_TITLE }}
     environment: staging
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -22,6 +22,10 @@ jobs:
     outputs:
       yarn_version: ${{ steps.set_yarn_version.outputs.yarn_version }}
     environment: staging
+    env:
+      SANITY_API_VERSION: ${{ vars.SANITY_API_VERSION }}
+      SANITY_DATASET: ${{ vars.SANITY_STUDIO_DATASET }}
+      SANITY_STUDIO_TITLE: ${{ vars.SANITY_STUDIO_TITLE }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,6 +107,11 @@ jobs:
       yarn_version: ${{ steps.set_yarn_version.outputs.yarn_version }}
     needs: [changes]
     environment: development
+    env:
+      SANITY_API_VERSION: ${{ vars.SANITY_API_VERSION }}
+      SANITY_DATASET: ${{ vars.SANITY_STUDIO_DATASET }}
+      SANITY_STUDIO_TITLE: ${{ vars.SANITY_STUDIO_TITLE }}
+      SANITY_DEVELOPER_TOKEN: ${{ secrets.SANITY_DEVELOPER_TOKEN }}
     if: ${{ (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true') }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,6 @@ jobs:
     needs: [changes, build]
     if: ${{ github.event_name == 'pull_request' }}
     env:
-      SANITY_PROJECT_ID: ${{ vars.SANITY_PROJECT_ID }}
       SANITY_API_VERSION: ${{ vars.SANITY_API_VERSION }}
       SANITY_DATASET: ${{ vars.SANITY_STUDIO_DATASET }}
       SANITY_DEVELOPER_TOKEN: ${{ secrets.SANITY_DEVELOPER_TOKEN }}
@@ -194,7 +193,6 @@ jobs:
     needs: [changes, build]
     if: ${{ github.event_name == 'pull_request' }}
     env:
-      SANITY_PROJECT_ID: ${{ vars.SANITY_PROJECT_ID }}
       SANITY_API_VERSION: ${{ vars.SANITY_API_VERSION }}
       SANITY_DATASET: ${{ vars.SANITY_STUDIO_DATASET }}
       SANITY_DEVELOPER_TOKEN: ${{ secrets.SANITY_DEVELOPER_TOKEN }}
@@ -228,7 +226,6 @@ jobs:
     if: ${{ needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request' }}
     needs: [changes, build]
     env:
-      SANITY_PROJECT_ID: ${{ vars.SANITY_PROJECT_ID }}
       SANITY_API_VERSION: ${{ vars.SANITY_API_VERSION }}
       SANITY_DATASET: ${{ vars.SANITY_STUDIO_DATASET }}
       SANITY_DEVELOPER_TOKEN: ${{ secrets.SANITY_DEVELOPER_TOKEN }}
@@ -266,7 +263,6 @@ jobs:
     if: ${{ needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request' }}
     needs: [changes, build]
     env:
-      SANITY_PROJECT_ID: ${{ vars.SANITY_PROJECT_ID }}
       SANITY_API_VERSION: ${{ vars.SANITY_API_VERSION }}
       SANITY_DATASET: ${{ vars.SANITY_STUDIO_DATASET }}
       SANITY_DEVELOPER_TOKEN: ${{ secrets.SANITY_DEVELOPER_TOKEN }}
@@ -304,7 +300,6 @@ jobs:
     if: ${{ needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request' }}
     needs: [changes, build]
     env:
-      SANITY_PROJECT_ID: ${{ vars.SANITY_PROJECT_ID }}
       SANITY_API_VERSION: ${{ vars.SANITY_API_VERSION }}
       SANITY_DATASET: ${{ vars.SANITY_STUDIO_DATASET }}
       SANITY_DEVELOPER_TOKEN: ${{ secrets.SANITY_DEVELOPER_TOKEN }}
@@ -341,6 +336,10 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref_name == 'dev' }}
     env:
       YARN_VERSION: ${{ needs.build.outputs.yarn_version }}
+      SANITY_API_VERSION: ${{ vars.SANITY_API_VERSION }}
+      SANITY_DATASET: ${{ vars.SANITY_STUDIO_DATASET }}
+      SANITY_DEVELOPER_TOKEN: ${{ secrets.SANITY_DEVELOPER_TOKEN }}
+      SANITY_STUDIO_TITLE: ${{ vars.SANITY_STUDIO_TITLE }}
     runs-on: ubuntu-${{ vars.RUNNER_VERSION }}
     environment: development
     needs: [changes, build]

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,svelte}": ["prettier --write", "eslint"],
-    "*.{html,css,json}": ["prettier --write"],
+    "*.{html,css,json,yaml,yml}": ["prettier --write"],
     "*.nix": "nixfmt"
   },
   "dependencies": {


### PR DESCRIPTION
### Description

The CI actions now include environment variables related to sanity in the build process.

This should fix failing backend cloudflare CI deployment. This is the current error:

```json
{
  "error": {
    "fileName": "https://dev.oms-sanity.pages.dev/static/sanity-BIMZ5sPD.js",
    "lineNumber": 1289,
    "columnNumber": 3430,
    "message": "`dataset` must be provided to perform queries"
  },
  "eventId": null
}
```

If this doesn't fix it, I may be at wits end!

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
