### PR TITLE
build: use `corepack` and not `yarn-berry` for nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
           # Development related
           # Node version matches that on the CI runners.
           nodejs_22
-          yarn-berry
+          corepack
           typescript
           typescript-language-server
           nixfmt-rfc-style


### PR DESCRIPTION
### Description

Use corepack not yarn-berry for install.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
