### PR TITLE
bug: Update +layout.svelte min-h-screen for mobile header

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,9 @@ export default defineConfig([
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        project: true,
+        projectService: {
+          allowDefaultProject: ['*.js'],
+        },
         tsconfigRootDir: import.meta.dirname,
         extraFileExtensions: ['.svelte'],
       },

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -5,7 +5,7 @@ export default {
     title: 'Format/Lint TS/React/Svelte',
     task: async (/** @type {string[]} */ files) => [
       `prettier --write ${files.join(' ')}`,
-      `eslint --fix ${files.join(' ')}`,
+      `eslint --fix --cache --no-warn-ignored ${files.join(' ')}`,
     ],
   },
   '**/*.(html|css|json|yaml|yml)': {

--- a/packages/frontend/eslint.config.mjs
+++ b/packages/frontend/eslint.config.mjs
@@ -5,6 +5,7 @@ import svelte from 'eslint-plugin-svelte'
 import baseConfig from '../../eslint.config.mjs'
 import svelteConfig from './svelte.config.js'
 import ts from 'typescript-eslint'
+import eslintConfigPrettier from 'eslint-config-prettier'
 
 export default defineConfig([
   ...baseConfig,
@@ -31,10 +32,13 @@ export default defineConfig([
       parserOptions: {
         tsconfigRootDir: import.meta.dirname,
         parser: tsParser,
-        projectService: true,
+        projectService: {
+          allowDefaultProject: ['*.js'],
+        },
         extraFileExtensions: ['.svelte'],
         svelteConfig,
       },
     },
   },
+  eslintConfigPrettier,
 ])

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -52,6 +52,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.2.9",
     "eslint": "^9.39.2",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-svelte": "^3.13.1",
     "playwright-core": "^1.57.0",
     "prettier": "^3.7.4",

--- a/packages/frontend/src/routes/(home)/+layout.svelte
+++ b/packages/frontend/src/routes/(home)/+layout.svelte
@@ -43,7 +43,7 @@ let headlineMediaBlurHash = $derived(data.articles[0].media?.blurHash)
 
       <!-- Mobile header -->
     </div>
-    <div class="block sm:hidden h-screen">
+    <div class="block sm:hidden min-h-screen">
       <div class="flex flex-col h-full">
         <div class="flex flex-col min-h-xl grow items-end p-3">
           <h1 class="w-full h-fit m-1 p-2 font-serif leading-8 text-6xl font-stretch-condensed">

--- a/yarn.lock
+++ b/yarn.lock
@@ -10048,6 +10048,7 @@ __metadata:
     "@unpic/placeholder": "npm:^0.1.2"
     "@unpic/svelte": "npm:^1.0.1"
     eslint: "npm:^9.39.2"
+    eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-svelte: "npm:^3.13.1"
     groq: "npm:^4.21.1"
     playwright-core: "npm:^1.57.0"


### PR DESCRIPTION
Replaced h-screen with min-h-screen to fix text overlap issue on mobile

### Description

Used min-h-screen for mobile header to stop text overlay bug

### Checklist

- [✓] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
